### PR TITLE
Added lookup table for float16 to float32

### DIFF
--- a/float16.go
+++ b/float16.go
@@ -1,0 +1,13 @@
+package rknnlite
+
+import "github.com/x448/float16"
+
+var f16LookupTable [65536]float32
+
+func init() {
+	// precompute float16 lookup table for faster conversion to float32
+	for i := range f16LookupTable {
+		f16 := float16.Frombits(uint16(i))
+		f16LookupTable[i] = f16.Float32()
+	}
+}

--- a/inference.go
+++ b/inference.go
@@ -8,7 +8,6 @@ package rknnlite
 import "C"
 import (
 	"fmt"
-	"github.com/x448/float16"
 	"gocv.io/x/gocv"
 	"sync"
 	"unsafe"
@@ -240,8 +239,7 @@ func convertFloat16BufferToFloat32(float16Buf []uint16) []float32 {
 	float32Buf := make([]float32, len(float16Buf))
 
 	for i, val := range float16Buf {
-		f16 := float16.Frombits(val)
-		float32Buf[i] = f16.Float32()
+		float32Buf[i] = f16LookupTable[val]
 	}
 
 	return float32Buf


### PR DESCRIPTION
On RK3588 using a lookup table to convert float 16 to float32 provides speed up on 35%.

BenchmarkF16toF32NormalConversion-8          150           7872802 ns/op         1720348 B/op          1 allocs/op
BenchmarkF16toF32LookupConversion-8          218           5123550 ns/op         1720342 B/op          1 allocs/op

On Threadripper workstation, a 3.3x speed up.

BenchmarkF16toF32NormalConversion-20                1302            916041 ns/op         1720322 B/op          1 allocs/op
BenchmarkF16toF32LookupConversion-20                3919            275437 ns/op         1720335 B/op          1 allocs/op
