### PR TITLE
Add skipping setting of runtime coremask for rk3566

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ the average inference speed down to 1.65ms per image.
 See the [Pool example](example/pool).
 
 
+## Other Rockchip Models
+
+For other Rockchip models such as the RK3566 which features a single NPU core, initialise
+the Runtime with the `rknnlite.NPUSkipSetCore` flag as follows.
+
+```
+rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUSkipSetCore)
+```
+
+
 ## CPU Affinity
 
 The performance of the NPU is effected by which CPU cores your program runs on, so

--- a/runtime.go
+++ b/runtime.go
@@ -21,12 +21,13 @@ type CoreMask int
 // DepthwiseConvolution, Add, Concat, Relu, Clip, Relu6, ThresholdedRelu, Prelu,
 // and LeakyRelu. Other type of ops will fallback to Core0 to continue running
 const (
-	NPUCoreAuto CoreMask = C.RKNN_NPU_CORE_AUTO
-	NPUCore0    CoreMask = C.RKNN_NPU_CORE_0
-	NPUCore1    CoreMask = C.RKNN_NPU_CORE_1
-	NPUCore2    CoreMask = C.RKNN_NPU_CORE_2
-	NPUCore01   CoreMask = C.RKNN_NPU_CORE_0_1
-	NPUCore012  CoreMask = C.RKNN_NPU_CORE_0_1_2
+	NPUCoreAuto    CoreMask = C.RKNN_NPU_CORE_AUTO
+	NPUCore0       CoreMask = C.RKNN_NPU_CORE_0
+	NPUCore1       CoreMask = C.RKNN_NPU_CORE_1
+	NPUCore2       CoreMask = C.RKNN_NPU_CORE_2
+	NPUCore01      CoreMask = C.RKNN_NPU_CORE_0_1
+	NPUCore012     CoreMask = C.RKNN_NPU_CORE_0_1_2
+	NPUSkipSetCore CoreMask = 9999
 )
 
 // ErrorCodes
@@ -118,10 +119,14 @@ func NewRuntime(modelFile string, core CoreMask) (*Runtime, error) {
 		return nil, err
 	}
 
-	err = r.setCoreMask(core)
+	// setCoreMask is only supported on RK3588, allow skipping for other Rockchip models
+	// like RK3566
+	if core != NPUSkipSetCore {
+		err = r.setCoreMask(core)
 
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// cache IONumber


### PR DESCRIPTION
This change fixes issue #22 with the setcoremask call when initialising the RKNN runtime on RK3566 which has a single NPU core.