### PR TITLE
Changed NewPool() function to require passing a list of NPUCores

### DIFF
--- a/example/pool/pool.go
+++ b/example/pool/pool.go
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// create new pool
-	pool, err := rknnlite.NewPool(*poolSize, *modelFile)
+	pool, err := rknnlite.NewPool(*poolSize, *modelFile, rknnlite.RK3588)
 
 	if err != nil {
 		log.Fatalf("Error creating RKNN pool: %v\n", err)

--- a/example/stream/bytetrack.go
+++ b/example/stream/bytetrack.go
@@ -133,7 +133,7 @@ type Demo struct {
 // NewDemo returns and instance of Demo, a streaming HTTP server showing
 // video with object detection
 func NewDemo(vidSrc *VideoSource, modelFile, labelFile string, poolSize int,
-	modelType string, renderFormat string) (*Demo, error) {
+	modelType string, renderFormat string, cores []rknnlite.CoreMask) (*Demo, error) {
 
 	var err error
 
@@ -152,7 +152,7 @@ func NewDemo(vidSrc *VideoSource, modelFile, labelFile string, poolSize int,
 	}
 
 	// create new pool
-	d.pool, err = rknnlite.NewPool(poolSize, modelFile)
+	d.pool, err = rknnlite.NewPool(poolSize, modelFile, cores)
 
 	if err != nil {
 		log.Fatalf("Error creating RKNN pool: %v\n", err)
@@ -748,7 +748,7 @@ func main() {
 	}
 
 	demo, err := NewDemo(vidSrc, *modelFile, *labelFile, *poolSize,
-		*modelType, *renderFormat)
+		*modelType, *renderFormat, rknnlite.RK3588)
 
 	if err != nil {
 		log.Fatalf("Error creating demo: %v", err)

--- a/runtime.go
+++ b/runtime.go
@@ -30,6 +30,18 @@ const (
 	NPUSkipSetCore CoreMask = 9999
 )
 
+var (
+	// A list of Rockchip models and the NPU core masks used for each.
+	// These are provided for passing to NewPool() to define which NPU
+	// cores to pin the Model and Runtime too.
+	RK3588 = []CoreMask{NPUCore0, NPUCore1, NPUCore2}
+	RK3582 = []CoreMask{NPUCore0, NPUCore1, NPUCore2}
+	RK3576 = []CoreMask{NPUCore0, NPUCore1}
+	RK3568 = []CoreMask{NPUCore0}
+	RK3566 = []CoreMask{NPUCore0}
+	RK3562 = []CoreMask{NPUCore0}
+)
+
 // ErrorCodes
 type ErrorCodes int
 


### PR DESCRIPTION
Pass NPUCores as a list when using NewPool() so other Rockchip RK35xx models that have single or dual NPU cores can use the Pool functionality.