### PR TITLE
Add docker file to run examples and inferencing in prebuilt environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,110 @@
+# Stage 1: Build OpenCV from source
+FROM golang:1.24.2-bookworm AS builder
+
+# Install build dependencies for OpenCV
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    build-essential \
+    git \
+    wget \
+    curl \
+    pkg-config \
+    libgtk-3-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libtbbmalloc2 \
+    libv4l-dev \
+    libxvidcore-dev \
+    libx264-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libtiff-dev \
+    gfortran \
+    openexr \
+    libatlas-base-dev \
+    python3-dev \
+    python3-numpy \
+    libtbb-dev \
+    libdc1394-dev \
+    libharfbuzz-dev \
+    libfreetype6-dev \
+    libgstreamer1.0-dev \
+    libgstreamer-plugins-base1.0-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the OpenCV version to build (adjust as needed)
+ENV OPENCV_VERSION=4.11.0
+
+# Clone OpenCV and opencv_contrib repositories and checkout the desired version
+RUN git clone https://github.com/opencv/opencv.git /opencv && \
+    cd /opencv && git checkout ${OPENCV_VERSION} && \
+    git clone https://github.com/opencv/opencv_contrib.git /opencv_contrib && \
+    cd /opencv_contrib && git checkout ${OPENCV_VERSION}
+
+# Build OpenCV with opencv_contrib modules
+RUN mkdir -p /opencv/build && cd /opencv/build && \
+    cmake -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_INSTALL_PREFIX=/usr/local \
+          -D OPENCV_EXTRA_MODULES_PATH=/opencv_contrib/modules \
+          -D BUILD_DOCS=OFF \
+          -D BUILD_EXAMPLES=OFF \
+          -D BUILD_TESTS=OFF \
+          -D BUILD_PERF_TESTS=ON \
+          -D BUILD_opencv_java=OFF \
+          -D BUILD_opencv_python=NO \
+          -D BUILD_opencv_python2=NO \
+          -D BUILD_opencv_python3=NO \
+          -D WITH_JASPER=OFF \
+          -D WITH_TBB=ON \
+          -D OPENCV_GENERATE_PKGCONFIG=ON \
+          -D WITH_FREETYPE=ON \
+          -D WITH_GSTREAMER=ON \
+          .. && \
+    make -j"$(nproc)" && \
+    make install || (echo "CMake failed, printing logs:" && \
+        cat CMakeFiles/CMakeError.log && \
+        cat CMakeFiles/CMakeOutput.log && exit 1)
+
+# Stage 2: Create the final image with Go, precompiled OpenCV, and GoCV
+FROM golang:1.24.2-bookworm
+
+# Install runtime dependencies needed by OpenCV (e.g., GStreamer and FFmpeg libraries)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgstreamer1.0-0 \
+    libgstreamer-plugins-base1.0-0 \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libgtk-3-0 \
+    libtbb12 \
+    libwebpdemux2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy installed OpenCV libraries and headers from the builder stage
+COPY --from=builder /usr/local /usr/local
+
+# Ensure pkg-config can locate OpenCV's .pc files
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+
+# Set LD_LIBRARY_PATH so that the dynamic linker can find OpenCV libraries
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+# Set working directory
+WORKDIR /go/src/versiontest
+
+# If a go.mod doesn't already exist, initialize a temporary module.
+# (This helps when running "go get" so that a module context is present.)
+RUN go mod init tmp || true
+
+# Set the GoCV version to build (adjust as needed)
+ENV GOCV_VERSION=v0.41.0
+
+# Download the GoCV package and build a sample application to verify integration
+RUN go get -v gocv.io/x/gocv@${GOCV_VERSION} && \
+    echo 'package main; import ("fmt"; "runtime"; "gocv.io/x/gocv"); func main() { fmt.Println("Go version:", runtime.Version()); fmt.Println("GoCV version:", gocv.Version()); fmt.Println("OpenCV version:", gocv.OpenCVVersion()) }' > main.go && \
+    go build -o version main.go
+
+# By default, run the sample application
+CMD ["./version"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libswscale-dev \
     libgtk-3-0 \
     libtbb12 \
+    ffmpeg \
     libwebpdemux2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,296 @@
+
+# How to Install
+
+## Dependencies
+
+go-rknnlite has a number of dependencies that are required.
+
+The [rknn-toolkit2](https://github.com/airockchip/rknn-toolkit2) must be installed on
+your system with C header files and libraries available in the system path, 
+eg: `/usr/include/rknn_api.h` and `/usr/lib/librknnrt.so`.  If your using an
+official OS image provided by your SBC vendor these files probably already exist.
+
+[GoCV](https://gocv.io/) is used for image processing.  Depending on GoCV's configuration this
+has subdependencies such as OpenCV, FFMpeg, GStreamer etc which make for a complicated
+build process. You can either follow [GoCV's installation instructions](https://github.com/hybridgroup/gocv/tree/release#how-to-install)
+or follow our instructions below.
+
+
+## Installation Options
+
+We provide the following installation options.
+
+* [Docker Image](#docker-install) - Use a prebuilt docker container
+* Manual Installation - Step by step instructions you can manually execute on CLI
+  * [Debian 12 (Bookworm)](#debian-12-bookworm)
+
+You can install on other Linux OS's, the Manual Installation instructions can assist 
+you in that process but some variation maybe needed.
+
+
+## Docker Install
+
+A prebuilt [docker image](https://hub.docker.com/repository/docker/swdee/go-rknnlite/general) 
+is available as `swdee/go-rknnlite:latest` which contains a Debian bookworm OS base with
+Golang, OpenCV, and GoCV configured.
+
+You can use this image to run your own application or the go-rknnlite examples.  For example
+to run the [MobileNet Demo](example/mobilenet) use the following commands.
+
+```
+cd example/mobilenet
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/../data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run mobilenet.go
+```
+
+An explanation of each parameter in the docker command is as follows;
+
+| Parameter                                            | Description                                                     |
+|------------------------------------------------------|-----------------------------------------------------------------| 
+| --device /dev/dri:/dev/dri                           | Pass the NPU device through into the container                  |
+| -v "$(pwd):/go/src/app"                              | Mount the current Go application source code into the container |
+| -v "$(pwd)/../data:/go/src/data"                     | Mount the example/data files into the container                 |
+| -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" | Include the rknn-toolkit2 header files                          |
+| -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so"     | Include the rknn-toolkit2 shared library                        |
+| -w /go/src/app                                       | Set the working directory in docker container                   |
+| swdee/go-rknnlite:latest                             | Use the prebuilt go-rknnlite docker image                       |
+| go run mobilenet.go                                  | Run the mobilenet.go demo                                       |
+
+
+To view the OpenCV configuration in this prebuilt docker image run.
+```
+docker run --rm swdee/go-rknnlite:latest opencv_version --verbose
+```
+
+
+### Build your own Docker Image
+
+You can also build your own docker image using the [Dockerfile](Dockerfile) in this directory, this allows
+you to make customisations or change any versions of software to suit your application.
+
+To change the Go version refer to the official Go build [tags here](https://hub.docker.com/_/golang )
+and change the base image.
+
+```
+FROM golang:1.24.2-bookworm AS builder
+```
+
+You may also set the OpenCV and GoCV versions with the following variables.
+```
+ENV OPENCV_VERSION=4.11.0
+ENV GOCV_VERSION=v0.41.0
+```
+
+Refer to the upstream project GoCV for version numbers as the OpenCV and GoCV 
+versions must be compatible.
+
+
+Run the following command to build your custom docker image.  It takes
+approximately 25 minutes to build on RK3588 based SBC.
+```
+cd env/
+docker build --progress=plain -t my-go-rknnlite .
+```
+
+Once successfully built run the image to confirm compiled program versions.
+```
+docker run --rm my-go-rknnlite
+```
+
+Output from the docker container.
+```
+Go version: go1.24.2
+GoCV version: 0.41.0
+OpenCV version: 4.11.0
+```
+
+
+## Manual Installation
+
+## Debian 12 (Bookworm)
+
+These manual instructions for Debian 12 (Bookworm) provide the steps to compile
+a working environment.
+
+
+### Install Go
+
+Install latest Go package available on APT repository.   You can use other versions
+at your own choice.
+```
+sudo apt install golang-1.23
+```
+
+Symlink the Go 1.13 binaries to system paths.
+```
+sudo ln -s /usr/lib/go-1.23/bin/go /usr/local/bin/go
+sudo ln -s /usr/lib/go-1.23/bin/gofmt /usr/local/bin/gofmt
+```
+
+Confirm Go is installed and working.
+```
+go version
+```
+
+
+### Install Required Packages
+
+Install required packages needed to build OpenCV which includes ffmpeg and
+gstreamer support.
+```
+sudo apt-get install -y --no-install-recommends \
+    cmake \
+    build-essential \
+    git \
+    wget \
+    curl \
+    pkg-config \
+    libgtk-3-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libtbbmalloc2 \
+    libv4l-dev \
+    libxvidcore-dev \
+    libx264-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libtiff-dev \
+    gfortran \
+    openexr \
+    libatlas-base-dev \
+    python3-dev \
+    python3-numpy \
+    libtbb-dev \
+    libdc1394-dev \
+    libharfbuzz-dev \
+    libfreetype6-dev \
+    libgstreamer1.0-dev \
+    libgstreamer-plugins-base1.0-dev    
+```
+
+Note: On Radxa's Debian image we also needed to install `librga-dev` for gstreamer
+support to be built.  This is an additional library that provides 2D hardware
+acceleration for Rockchip devices and is a part of Radxa's APT repository.
+```
+sudo apt install librga-dev
+```
+
+
+Clone OpenCV repository and checkout the desired version by
+replacing the `OPENCV_VERSION` text with `4.11.0` for example.
+```
+cd /tmp
+
+git clone https://github.com/opencv/opencv.git opencv 
+cd opencv 
+git checkout OPENCV_VERSION
+```
+
+Clone OpenCV Contrib and checkout the same version as OpenCV above.
+```
+cd /tmp
+git clone https://github.com/opencv/opencv_contrib.git opencv_contrib
+cd opencv_contrib 
+git checkout OPENCV_VERSION 
+```
+
+Create build directory for OpenCV.
+```
+cd /tmp/opencv
+mkdir build
+cd build
+```
+
+Configure OpenCV.
+```
+cmake -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX=/usr/local \
+    -D OPENCV_EXTRA_MODULES_PATH=/tmp/opencv_contrib/modules \
+    -D BUILD_DOCS=OFF \
+    -D BUILD_EXAMPLES=OFF \
+    -D BUILD_TESTS=OFF \
+    -D BUILD_PERF_TESTS=ON \
+    -D BUILD_opencv_java=OFF \
+    -D BUILD_opencv_python=NO \
+    -D BUILD_opencv_python2=NO \
+    -D BUILD_opencv_python3=NO \
+    -D WITH_JASPER=OFF \
+    -D WITH_TBB=ON \
+    -D OPENCV_GENERATE_PKGCONFIG=ON \
+    -D WITH_FREETYPE=ON \
+    -D WITH_GSTREAMER=ON \
+    ..
+```
+
+Check the configuration output to make sure all OpenCV features you want are included.
+
+
+Compile and install.  It takes about 25 minutes to compile on a RK3588 based SBC.
+```
+make -j"$(nproc)" && sudo make install    
+```
+
+Check installation.
+```
+opencv_version --verbose
+```
+
+Clean up and remove files.
+```
+cd /tmp
+rm -rf opencv/ opencv_contrib/
+```
+
+
+
+## Maintainer Notes Only
+
+The following notes are for the go-rknnlite maintainer only, you do not need to do these.
+
+
+### Building Docker Image
+
+
+Building the docker image.
+```
+cd env/
+docker build --progress=plain -t swdee/go-rknnlite:latest .
+```
+
+Check version after build is complete.
+```
+docker run --rm go-rknnlite:latest
+```
+
+
+### Uploading to Docker Hub 
+
+Login to docker hub.
+```
+docker login
+```
+
+Push the tagged image as latest.
+```
+docker push swdee/go-rknnlite:latest
+```
+
+Create a version number for this latest image.
+```
+docker tag swdee/go-rknnlite:latest swdee/go-rknnlite:1.0.0
+```
+
+Push the versioned image.
+```
+docker push swdee/go-rknnlite:1.0.0
+```
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ We provide the following installation options.
 * Manual Installation - Step by step instructions you can manually execute on CLI
   * [Debian 12 (Bookworm)](#debian-12-bookworm)
 
-You can install on other Linux OS's, the Manual Installation instructions can assist 
+You can install on other Linux distributions, the Manual Installation instructions can assist 
 you in that process but some variation maybe needed.
 
 
@@ -243,10 +243,69 @@ Check installation.
 opencv_version --verbose
 ```
 
+Update system shared library cache (LD library).
+```
+sudo ldconfig
+```
+
 Clean up and remove files.
 ```
 cd /tmp
 rm -rf opencv/ opencv_contrib/
+```
+
+### Test GoCV
+
+Create a simple program to download and run GoCV.
+
+```
+cd /tmp
+mkdir testgocv
+cd testgocv
+```
+
+Create file `/tmp/testgocv/main.go` with contents;
+
+```
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"gocv.io/x/gocv"
+)
+
+func main() {
+	fmt.Println("Go version:", runtime.Version())
+	fmt.Println("GoCV version:", gocv.Version())
+	fmt.Println("OpenCV version:", gocv.OpenCVVersion())
+}
+```
+
+Make test program a Go module.
+```
+go mod init testgocv
+go mod tidy
+```
+
+Run test program.  Note the first run takes a while as Go compiles the CGO to OpenCV,
+but subsequent runs are cached and run quickly.
+
+```
+go run main.go
+```
+
+Output from test program.
+```
+Go version: go1.23.5
+GoCV version: 0.41.0
+OpenCV version: 4.11.0
+```
+
+Clean up and remove test program
+```
+cd /tmp
+rm -rf testgocv/
 ```
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,7 +96,6 @@ versions must be compatible.
 Run the following command to build your custom docker image.  It takes
 approximately 25 minutes to build on RK3588 based SBC.
 ```
-cd env/
 docker build --progress=plain -t my-go-rknnlite .
 ```
 
@@ -262,7 +261,6 @@ The following notes are for the go-rknnlite maintainer only, you do not need to 
 
 Building the docker image.
 ```
-cd env/
 docker build --progress=plain -t swdee/go-rknnlite:latest .
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,17 +38,17 @@ You can use this image to run your own application or the go-rknnlite examples. 
 to run the [MobileNet Demo](example/mobilenet) use the following commands.
 
 ```
-cd example/mobilenet
+# from project root directory
 
 docker run --rm \
   --device /dev/dri:/dev/dri \
   -v "$(pwd):/go/src/app" \
-  -v "$(pwd)/../data:/go/src/data" \
+  -v "$(pwd)/example/data:/go/src/data" \
   -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run mobilenet.go
+  go run ./example/mobilenet/mobilenet.go  
 ```
 
 An explanation of each parameter in the docker command is as follows;
@@ -57,12 +57,12 @@ An explanation of each parameter in the docker command is as follows;
 |------------------------------------------------------|-----------------------------------------------------------------| 
 | --device /dev/dri:/dev/dri                           | Pass the NPU device through into the container                  |
 | -v "$(pwd):/go/src/app"                              | Mount the current Go application source code into the container |
-| -v "$(pwd)/../data:/go/src/data"                     | Mount the example/data files into the container                 |
+| -v "$(pwd)/example/data:/go/src/data"                | Mount the example/data files into the container                 |
 | -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" | Include the rknn-toolkit2 header files                          |
 | -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so"     | Include the rknn-toolkit2 shared library                        |
 | -w /go/src/app                                       | Set the working directory in docker container                   |
 | swdee/go-rknnlite:latest                             | Use the prebuilt go-rknnlite docker image                       |
-| go run mobilenet.go                                  | Run the mobilenet.go demo                                       |
+| go run ./example/mobilenet/mobilenet.go              | Run the mobilenet.go demo                                       |
 
 
 To view the OpenCV configuration in this prebuilt docker image run.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ See the [example](example) directory.
   * [HTTP Stream with ByteTrack Tracking](example/stream) - Demo that streams a video over HTTP with YOLO object detection and ByteTrack object tracking.  
 
 
+## Converting Inference Models
+
+To convert your inference model into the required `.rknn` format to run on the NPU, see the
+[vendor instructions](https://github.com/airockchip/rknn_model_zoo/tree/main/examples/yolov8#4-convert-to-rknn) 
+in the Model Zoo.
+
+Each Model has its own `convert.py` script contained in the vendors project.  You may
+need to modify this python script for your own Models depending on how they were trained.   
+
+Run the `convert.py` script on your x86 workstation to perform the conversion.
+
+
+
+
 ## Pooled Runtimes
 
 Running multiple Runtimes in a Pool allows you to take advantage of all three

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Then refer to the Readme files for each example to run on command line.
 
 ## Dependencies
 
-The [rknn-toolkit2](https://github.com/airockchip/rknn-toolkit2) must be installed on 
-your system with C header files available in the system path, eg: `/usr/include/rknn_api.h`.
+The [rknn-toolkit2](https://github.com/airockchip/rknn-toolkit2) must be installed on
+your system with C header files and libraries available in the system path,
+eg: `/usr/include/rknn_api.h` and `/usr/lib/librknnrt.so`.  If your using an
+official OS image provided by your SBC vendor these files probably already exist.
 
 Refer to the official documentation on how to install this on your system as it
 will vary based on OS and SBC vendor.
@@ -63,8 +65,9 @@ The output should list the driver and indicate the NPU is initialized.
 ### GoCV
 
 The examples make use of [GoCV](https://gocv.io/) for image processing.  Make sure
-you have a working installation of GoCV first, see the instructions in the link
-for installation on your system.
+you have a working installation of GoCV first, see the [How to Install](INSTALL.md)
+instructions that provide details on prebuilt docker images or manual
+installation.
 
 
 

--- a/example/alpr/README.md
+++ b/example/alpr/README.md
@@ -76,4 +76,22 @@ Usage of /tmp/go-build506851743/b001/exe/alpr:
         The text drawing mode [cn|en] (default "cn")
 ```
 
+### Docker
+
+To run the ALPR example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/alpr/alpr.go
+```
+
 

--- a/example/lprnet/README.md
+++ b/example/lprnet/README.md
@@ -37,6 +37,25 @@ To use your own RKNN compiled model and images.
 go run lprnet.go -m <RKNN model file> -i <image file>
 ```
 
+### Docker
+
+To run the ALPR example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/lprnet/lprnet.go
+```
+
+
 ## Proprietary Models
 
 This example makes use of the [Chinese License Plate Recognition LPRNet](https://github.com/sirius-ai/LPRNet_Pytorch). 

--- a/example/mobilenet/README.md
+++ b/example/mobilenet/README.md
@@ -38,6 +38,25 @@ To use your own RKNN compiled model and images.
 go run mobilenet.go -m <RKNN model file> -i <image file>
 ```
 
+### Docker
+
+To run the MobileNet example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/mobilenet/mobilenet.go
+```
+
+
 ## Background
 
 This MobileNet example is a Go conversion of the [C API example](https://github.com/airockchip/rknn-toolkit2/blob/v1.6.0/rknpu2/examples/rknn_mobilenet_demo/src/main.cc).

--- a/example/mobilenet/go.mod
+++ b/example/mobilenet/go.mod
@@ -1,8 +1,0 @@
-module mobilenet
-
-go 1.22.8
-
-require (
-	github.com/swdee/go-rknnlite v0.0.0-20250401212925-399f18c77ec7
-	gocv.io/x/gocv v0.41.0
-)

--- a/example/mobilenet/go.mod
+++ b/example/mobilenet/go.mod
@@ -1,0 +1,8 @@
+module mobilenet
+
+go 1.22.8
+
+require (
+	github.com/swdee/go-rknnlite v0.0.0-20250401212925-399f18c77ec7
+	gocv.io/x/gocv v0.41.0
+)

--- a/example/mobilenet/go.sum
+++ b/example/mobilenet/go.sum
@@ -1,4 +1,0 @@
-github.com/swdee/go-rknnlite v0.0.0-20250401212925-399f18c77ec7 h1:l9IeY+65tm/QYa5wwcasSznwqj+EpC6br7oxHtnbZzE=
-github.com/swdee/go-rknnlite v0.0.0-20250401212925-399f18c77ec7/go.mod h1:/qJ6ExxC28AARBXGFDWTcjq4A6e6EDhw1IQm9x3sUJ0=
-gocv.io/x/gocv v0.41.0 h1:KM+zRXUP28b6dHfhy+4JxDODbCNQNtLg8kio+YE7TqA=
-gocv.io/x/gocv v0.41.0/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=

--- a/example/mobilenet/go.sum
+++ b/example/mobilenet/go.sum
@@ -1,0 +1,4 @@
+github.com/swdee/go-rknnlite v0.0.0-20250401212925-399f18c77ec7 h1:l9IeY+65tm/QYa5wwcasSznwqj+EpC6br7oxHtnbZzE=
+github.com/swdee/go-rknnlite v0.0.0-20250401212925-399f18c77ec7/go.mod h1:/qJ6ExxC28AARBXGFDWTcjq4A6e6EDhw1IQm9x3sUJ0=
+gocv.io/x/gocv v0.41.0 h1:KM+zRXUP28b6dHfhy+4JxDODbCNQNtLg8kio+YE7TqA=
+gocv.io/x/gocv v0.41.0/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=

--- a/example/pool/README.md
+++ b/example/pool/README.md
@@ -67,6 +67,26 @@ When selecting the number of Runtimes to initialize the pool with select 1, 2, 3
 a multiple of 3 to spread them across all three NPU cores.
 
 
+### Docker
+
+To run the Pool example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/pool/pool.go -q -s 3 -r 4
+```
+
+
+
 
 ## Benchmarks
 

--- a/example/ppocr/README.md
+++ b/example/ppocr/README.md
@@ -29,7 +29,7 @@ git clone https://github.com/swdee/go-rknnlite-data.git data
 
 ### Usage
 
-Run the PPOCR Recognition example.
+Run the PPOCR Detection example.
 ```
 cd example/ppocr
 go run detect.go common.go
@@ -68,6 +68,26 @@ done
 Bounding boxes have been drawn around detected text areas.
 
 ![detect-out.jpg](detect-out.jpg)
+
+
+### Docker
+
+To run the PPOCR Detection example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/ppocr/detect.go ./example/ppocr/common.go
+```
+
 
 
 ### Background
@@ -110,6 +130,26 @@ Sample images input and text detected.
 | ![region.jpg](region.jpg)         |    浙G·Z6825        | 0.65         |
 | ![cn-text.png](cn-text.png)       |    中华老字号        | 0.71          |
 | ![mozzarella.jpg](mozzarella.jpg) |    MOZZARELLA - 188        | 0.67  |
+
+
+### Docker
+
+To run the PPOCR Recognition example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/ppocr/recognise.go ./example/ppocr/common.go
+```
+
 
 
 ### Other Language Models
@@ -220,7 +260,7 @@ This PPOCR Recognise example is a Go conversion of the [C API example](https://g
 
 ### Usage
 
-Run the PPOCR Recognition example.
+Run the PPOCR System example.
 ```
 cd example/ppocr
 go run system.go common.go
@@ -282,6 +322,25 @@ done
 As can be seen all of the text area's from the image processed at the 
 PPOCR Detect stage have had OCR applied using PPOCR Recognise.  Displayed
 are the Chinese and English characters read from the OCR process.
+
+### Docker
+
+To run the PPOCR System example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/ppocr/system.go ./example/ppocr/common.go
+```
+
 
 
 ### Background

--- a/example/retinaface/README.md
+++ b/example/retinaface/README.md
@@ -67,6 +67,25 @@ Usage of /tmp/go-build3929104604/b001/exe/retinaface:
 ```
 
 
+### Docker
+
+To run the RetinaFace example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/retinaface/retinaface.go
+```
+
+
 
 ## Background
 

--- a/example/stream/README.md
+++ b/example/stream/README.md
@@ -70,6 +70,26 @@ https://github.com/user-attachments/assets/ee28fc00-1d07-4af0-bc77-171a3acde5ce
 
 
 
+### Docker
+
+To run the Stream example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm -it \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  -p 8080:8080 \
+  swdee/go-rknnlite:latest \
+  go run ./example/stream/bytetrack.go -a :8080 -s 3 -x person
+```
+
+
 ### Detailed Usage
 
 

--- a/example/yolov10/README.md
+++ b/example/yolov10/README.md
@@ -55,6 +55,26 @@ It should have one label per line.
 
 
 
+### Docker
+
+To run the YOLOv10 example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov10/yolov10.go
+```
+
+
+
 
 ## Proprietary Models
 

--- a/example/yolov11/README.md
+++ b/example/yolov11/README.md
@@ -60,6 +60,26 @@ It should have one label per line.
 
 
 
+### Docker
+
+To run the YOLOv11 example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov11/yolov11.go
+```
+
+
+
 ## Proprietary Models
 
 The example YOLOv11 model used has been trained on the COCO dataset so makes use

--- a/example/yolov5-seg/README.md
+++ b/example/yolov5-seg/README.md
@@ -67,6 +67,26 @@ Usage of /tmp/go-build401282281/b001/exe/yolov5-seg:
         The rendering format used for instance segmentation [outline|mask|dump] (default "outline")
 ```
 
+### Docker
+
+To run the YOLOv5-seg example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov5-seg/yolov5-seg.go
+```
+
+
+
 
 ## Rendering Methods
 

--- a/example/yolov5/README.md
+++ b/example/yolov5/README.md
@@ -53,6 +53,26 @@ The labels file should be a text file containing the labels the Model was traine
 It should have one label per line.
 
 
+### Docker
+
+To run the YOLOv5 example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov5/yolov5.go
+```
+
+
+
 ## Proprietary Models
 
 The example YOLOv5 model used has been trained on the COCO dataset so makes use

--- a/example/yolov8-obb/README.md
+++ b/example/yolov8-obb/README.md
@@ -93,6 +93,26 @@ Usage of /tmp/go-build3751821681/b001/exe/yolov8-obb:
 ```
 
 
+### Docker
+
+To run the YOLOv8-obb example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov8-obb/yolov8-obb.go
+```
+
+
+
 ## Background
 
 This YOLOv8-obb example is a Go conversion of the [C API example](https://github.com/airockchip/rknn_model_zoo/blob/main/examples/yolov8_obb/cpp/main.cc).

--- a/example/yolov8-pose/README.md
+++ b/example/yolov8-pose/README.md
@@ -64,6 +64,26 @@ Usage of /tmp/go-build1390906730/b001/exe/yolov8-pose:
 
 
 
+### Docker
+
+To run the YOLOv8-pose example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov8-pose/yolov8-pose.go
+```
+
+
+
 ## Background
 
 This YOLOv8-pose example is a Go conversion of the [C API example](https://github.com/airockchip/rknn_model_zoo/blob/main/examples/yolov8_pose/cpp/main.cc).

--- a/example/yolov8-seg/README.md
+++ b/example/yolov8-seg/README.md
@@ -74,6 +74,27 @@ Usage of /tmp/go-build401282281/b001/exe/yolov8-seg:
 ```
 
 
+
+### Docker
+
+To run the YOLOv8-seg example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov8-seg/yolov8-seg.go
+```
+
+
+
 ## Rendering Methods
 
 The default rendering method is to draw an outline around the edge of the detected

--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -58,6 +58,25 @@ The labels file should be a text file containing the labels the Model was traine
 It should have one label per line.
 
 
+### Docker
+
+To run the YOLOv8 example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolov8/yolov8.go
+```
+
+
 
 ## Proprietary Models
 

--- a/example/yolox/README.md
+++ b/example/yolox/README.md
@@ -52,6 +52,25 @@ The labels file should be a text file containing the labels the Model was traine
 It should have one label per line.
 
 
+### Docker
+
+To run the YOLOX example using the prebuilt docker image, make sure the data files have been downloaded first,
+then run.
+```
+# from project root directory
+
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  -v "$(pwd):/go/src/app" \
+  -v "$(pwd)/example/data:/go/src/data" \
+  -v "/usr/include/rknn_api.h:/usr/include/rknn_api.h" \
+  -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
+  -w /go/src/app \
+  swdee/go-rknnlite:latest \
+  go run ./example/yolox/yolox.go
+```
+
+
 
 ## Proprietary Models
 

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,9 @@ go 1.21
 
 require (
 	github.com/ctessum/go.clipper v0.1.2
-	gocv.io/x/gocv v0.36.1
+	gocv.io/x/gocv v0.41.0
 	golang.org/x/image v0.16.0
 	gonum.org/v1/gonum v0.15.0
 )
 
-require (
-	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/text v0.15.0 // indirect
-)
+require golang.org/x/text v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
-github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
-github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-gocv.io/x/gocv v0.36.1 h1:6XkEaPOk7h/umjy+MXgSEtSeCIgcPJhccUjrJFhjdTY=
-gocv.io/x/gocv v0.36.1/go.mod h1:lmS802zoQmnNvXETpmGriBqWrENPei2GxYx5KUxJsMA=
+gocv.io/x/gocv v0.41.0 h1:KM+zRXUP28b6dHfhy+4JxDODbCNQNtLg8kio+YE7TqA=
+gocv.io/x/gocv v0.41.0/go.mod h1:zYdWMj29WAEznM3Y8NsU3A0TRq/wR/cy75jeUypThqU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
- added instructions to use prebuilt docker image containing OpenCV and GoCV for running inference.
- added manual installation instructions for debian 12 (bookworm) for setting up OpenCV and GoCV.
- Updated GoCV version