### PR TITLE
Optimized Yolov5/v8 Segmentation code

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -16,10 +16,10 @@ The `data/palace.jpg` image file was used for benchmarking.
 | YOLOv8s      | 44.8ms             | 47.5ms    | 5.0ms           | 4.2ms     |
 | YOLOv10s     | 49.4ms             | 57.1ms    | 2.9ms           | 4.1ms     |
 | YOLOXs       | 42.4ms             | 48.7ms    | 0.5ms           | 5.5ms     |
-| YOLOv11s     | 48.1ms             | 55.1ms    | 2.3ms         | 4.1ms     |
+| YOLOv11s     | 48.1ms             | 55.1ms    | 2.3ms           | 4.1ms     |
 | YOLOv8n-pose | 47.5ms             | 54.1ms    | 1.0ms           | 3.0ms     |
-| YOLOv5s-seg  | 207.5ms            | 57.0ms    | 107.6ms         | 75.9ms    |
-| YOLOv8s-seg  | 232.5ms            | 67.9ms    | 113.3ms         | 73.4ms    |
+| YOLOv5s-seg  | 106.1ms            | 45.0ms    | 68.4ms          | 4.8ms     |
+| YOLOv8s-seg  | 122.6ms            | 52.7ms    | 69.3ms          | 4.3ms     |
 
 The Inference, Post Processing, and Rendering columns show how processing time
 is split across the Total Time.   These figures are derived from the first

--- a/example/stream/bytetrack.go
+++ b/example/stream/bytetrack.go
@@ -514,6 +514,8 @@ func (d *Demo) ProcessFrame(img gocv.Mat, retChan chan<- ResultFrame,
 		keyPoints = d.process.(*postprocess.YOLOv8Pose).GetPoseEstimation(detectObjs)
 	}
 
+	timing.DetObjEnd = time.Now()
+
 	// annotate the image
 	d.AnnotateImg(resImg, detectResults, trackObjs, segMask, keyPoints,
 		trail, fps, frameNum, timing)
@@ -665,8 +667,6 @@ func (d *Demo) DetectObjects(img gocv.Mat, frameNum int,
 	timing.DetObjInferenceEnd = time.Now()
 
 	detectObjs := d.process.DetectObjects(outputs, d.resizer)
-
-	timing.DetObjEnd = time.Now()
 
 	// free outputs allocated in C memory after you have finished post processing
 	err = outputs.Free()

--- a/postprocess/bufpool.go
+++ b/postprocess/bufpool.go
@@ -1,0 +1,90 @@
+package postprocess
+
+import (
+	"fmt"
+	"sync"
+)
+
+// bufferPool holds a set of named buffer pools
+type bufferPool struct {
+	mu    sync.Mutex
+	pools map[string]*bufferEntry
+}
+
+// bufferEntry defines a single buffer
+type bufferEntry struct {
+	pool    sync.Pool
+	maxSize int
+}
+
+// NewBufferPool returns an empty segBufferPool.
+func NewBufferPool() *bufferPool {
+	return &bufferPool{
+		pools: make(map[string]*bufferEntry),
+	}
+}
+
+// Create registers a new pool under 'name' that will produce buffers
+// up to maxSize. Calling it twice with the same name returns an error.
+func (b *bufferPool) Create(name string, maxSize int) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, exists := b.pools[name]; exists {
+		return fmt.Errorf("buffer pool %q already exists", name)
+	}
+
+	entry := &bufferEntry{maxSize: maxSize}
+
+	entry.pool.New = func() any {
+		return make([]uint8, maxSize)
+	}
+
+	b.pools[name] = entry
+	return nil
+}
+
+// Get returns a []uint8 slice of length 'size' from the named pool.
+// If size > maxSize, it allocates a new slice of exactly size.
+// Panics if the pool name is unknown.
+func (b *bufferPool) Get(name string, size int) []uint8 {
+	b.mu.Lock()
+	entry, ok := b.pools[name]
+	b.mu.Unlock()
+
+	if !ok {
+		panic(fmt.Sprintf("buffer pool %q not registered", name))
+	}
+
+	buf := entry.pool.Get().([]uint8)
+
+	if cap(buf) < size {
+		return make([]uint8, size)
+	}
+
+	// get buffer of required size
+	buf = buf[:size]
+
+	// zero out the buffer
+	for i := range buf {
+		buf[i] = 0
+	}
+
+	return buf
+}
+
+// Put returns a buffer back into it's named pool.
+// You must only call Put on a buffer you previously got via Get
+// with the same name.
+func (b *bufferPool) Put(name string, buf []uint8) {
+	b.mu.Lock()
+	entry, ok := b.pools[name]
+	b.mu.Unlock()
+
+	if !ok {
+		panic(fmt.Sprintf("buffer pool %q not registered", name))
+	}
+
+	// restore to full capacity so it matches entry.New next time
+	entry.pool.Put(buf[:entry.maxSize])
+}

--- a/postprocess/common.go
+++ b/postprocess/common.go
@@ -285,42 +285,6 @@ func intInSlice(i int, arr []int) bool {
 	return false
 }
 
-// cropMaskWithIDUint8 for each objects segmentation mask combine it into a single
-// mask with each object assigned a unique ID to distinguish its mask from
-// other objects masks.
-func cropMaskWithIDUint8(segMask, allMaskInOne []uint8, boxes []int, boxesNum int,
-	height, width int, stripObjs []int) {
-
-	for b := 0; b < boxesNum; b++ {
-		x1 := boxes[b*4+0]
-		y1 := boxes[b*4+1]
-		x2 := boxes[b*4+2]
-		y2 := boxes[b*4+3]
-
-		for i := 0; i < height; i++ {
-			for j := 0; j < width; j++ {
-				if j >= x1 && j < x2 && i >= y1 && i < y2 {
-					if allMaskInOne[i*width+j] == 0 {
-						if segMask[b*height*width+i*width+j] > 0 {
-							// check if we strip this object out
-							if intInSlice(b, stripObjs) {
-
-								// strip out by marking as background
-								allMaskInOne[i*width+j] = 0
-							} else {
-								// Assign a unique object ID
-								allMaskInOne[i*width+j] = uint8(b + 1) // mark as object region
-							}
-						} else {
-							allMaskInOne[i*width+j] = 0 // mark as background
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
 // boxReverse scales detection box back to box for use on original image dimensions
 func boxReverse(pos int, pad int, scale float32) int {
 	return int(float32(pos-pad) / scale)

--- a/postprocess/matmul.go
+++ b/postprocess/matmul.go
@@ -5,94 +5,6 @@ import (
 	"sync"
 )
 
-// matmulUint8 performs matrix multiplication using the CPU
-func matmulUint8Org(data *strideData, boxesNum int, protoChannel int,
-	protoHeight int, protoWeight int) []uint8 {
-
-	A := data.filterSegmentsByNMS
-	B := data.proto
-	// C is matmulOut
-	C := make([]uint8, boxesNum*protoHeight*protoWeight)
-
-	rowsA := boxesNum
-	colsA := protoChannel
-	colsB := protoHeight * protoWeight
-
-	var temp float32
-
-	for i := 0; i < rowsA; i++ {
-		for j := 0; j < colsB; j++ {
-			temp = 0
-			for k := 0; k < colsA; k++ {
-				temp += A[i*colsA+k] * B[k*colsB+j]
-			}
-			if temp > 0 {
-				C[i*colsB+j] = 4 // an object
-			} else {
-				C[i*colsB+j] = 0 // background
-			}
-		}
-	}
-
-	return C
-}
-
-// matmulUint8Parallel performs matrix multiplication using the CPU with
-// optimization to process in parallel across goroutines
-func matmulUint8ParallelOrg(data *strideData, boxesNum int, protoChannel int,
-	protoHeight int, protoWeight int) []uint8 {
-
-	A := data.filterSegmentsByNMS
-	B := data.proto
-	C := make([]uint8, boxesNum*protoHeight*protoWeight)
-
-	rowsA := boxesNum
-	colsA := protoChannel
-	colsB := protoHeight * protoWeight
-
-	// use a worker pool based on available CPU cores
-	numWorkers := runtime.NumCPU()
-	rowCh := make(chan int, rowsA)
-
-	// worker function for performing the matrix multiplication on a row
-	worker := func() {
-		for i := range rowCh {
-			for j := 0; j < colsB; j++ {
-				var temp float32
-				for k := 0; k < colsA; k++ {
-					temp += A[i*colsA+k] * B[k*colsB+j]
-				}
-				if temp > 0 {
-					C[i*colsB+j] = 4 // an object
-				} else {
-					C[i*colsB+j] = 0 // background
-				}
-			}
-		}
-	}
-
-	// start the workers
-	var wg sync.WaitGroup
-	wg.Add(numWorkers)
-	for w := 0; w < numWorkers; w++ {
-		go func() {
-			defer wg.Done()
-			worker()
-		}()
-	}
-
-	// distribute rows to workers
-	for i := 0; i < rowsA; i++ {
-		rowCh <- i
-	}
-	close(rowCh)
-
-	// wait for all workers to complete
-	wg.Wait()
-
-	return C
-}
-
 // matmulUint8 is the straight‑line version: no channels or goroutines.
 func matmulUint8(data *strideData, boxesNum, protoChannel,
 	protoHeight, protoWeight int, C []uint8) {
@@ -147,14 +59,18 @@ func matmulUint8Parallel(data *strideData, boxesNum, protoChannel,
 	for w := 0; w < numWorkers; w++ {
 		go func(w int) {
 			defer wg.Done()
+
 			for i := w; i < rows; i += numWorkers {
 				baseA := i * colsA
 				baseC := i * colsB
+
 				for j := 0; j < colsB; j++ {
 					var sum float32
+
 					for k := 0; k < colsA; k++ {
 						sum += A[baseA+k] * B[k*colsB+j]
 					}
+
 					if sum > 0 {
 						C[baseC+j] = 4
 					}

--- a/postprocess/matmul.go
+++ b/postprocess/matmul.go
@@ -6,7 +6,7 @@ import (
 )
 
 // matmulUint8 performs matrix multiplication using the CPU
-func matmulUint8(data *strideData, boxesNum int, protoChannel int,
+func matmulUint8Org(data *strideData, boxesNum int, protoChannel int,
 	protoHeight int, protoWeight int) []uint8 {
 
 	A := data.filterSegmentsByNMS
@@ -39,7 +39,7 @@ func matmulUint8(data *strideData, boxesNum int, protoChannel int,
 
 // matmulUint8Parallel performs matrix multiplication using the CPU with
 // optimization to process in parallel across goroutines
-func matmulUint8Parallel(data *strideData, boxesNum int, protoChannel int,
+func matmulUint8ParallelOrg(data *strideData, boxesNum int, protoChannel int,
 	protoHeight int, protoWeight int) []uint8 {
 
 	A := data.filterSegmentsByNMS
@@ -91,4 +91,77 @@ func matmulUint8Parallel(data *strideData, boxesNum int, protoChannel int,
 	wg.Wait()
 
 	return C
+}
+
+// matmulUint8 is the straight‑line version: no channels or goroutines.
+func matmulUint8(data *strideData, boxesNum, protoChannel,
+	protoHeight, protoWeight int, C []uint8) {
+
+	A := data.filterSegmentsByNMS
+	B := data.proto
+
+	rows := boxesNum
+	colsA := protoChannel
+	colsB := protoHeight * protoWeight
+
+	// one big flat loop per row, per column, per channel
+	for i := 0; i < rows; i++ {
+
+		baseA := i * colsA
+		baseC := i * colsB
+
+		for j := 0; j < colsB; j++ {
+			var sum float32
+
+			// accumulate A[i,k] * B[k,j]
+			for k := 0; k < colsA; k++ {
+				sum += A[baseA+k] * B[k*colsB+j]
+			}
+
+			if sum > 0 {
+				C[baseC+j] = 4 // object
+			}
+
+			// else leave zero, which is the background
+		}
+	}
+}
+
+// matmulUint8Parallel splits the rows across NumCPU workers,
+// avoids a channel‐per‐row, and writes disjoint regions of C.
+func matmulUint8Parallel(data *strideData, boxesNum, protoChannel,
+	protoHeight, protoWeight int, C []uint8) {
+
+	A := data.filterSegmentsByNMS
+	B := data.proto
+
+	rows := boxesNum
+	colsA := protoChannel
+	colsB := protoHeight * protoWeight
+
+	numWorkers := runtime.NumCPU()
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+
+	// each worker handles rows i = w, w+numWorkers, w+2*numWorkers
+	for w := 0; w < numWorkers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := w; i < rows; i += numWorkers {
+				baseA := i * colsA
+				baseC := i * colsB
+				for j := 0; j < colsB; j++ {
+					var sum float32
+					for k := 0; k < colsA; k++ {
+						sum += A[baseA+k] * B[k*colsB+j]
+					}
+					if sum > 0 {
+						C[baseC+j] = 4
+					}
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
 }

--- a/postprocess/yolov5-seg.go
+++ b/postprocess/yolov5-seg.go
@@ -15,6 +15,10 @@ type YOLOv5Seg struct {
 	idGen *idGenerator
 	// protoSize is the Prototype tensor size of the Segment Mask
 	protoSize int
+	// buffer pools to stop allocation contention
+	bufPool *bufferPool
+	// bufPoolInit is a flag to indicate if the buffer pool has been initialized
+	bufPoolInit bool
 }
 
 // YOLOv5SegParams defines the struct containing the YOLOv5Seg parameters to use
@@ -111,6 +115,7 @@ func NewYOLOv5Seg(p YOLOv5SegParams) *YOLOv5Seg {
 		Params:    p,
 		idGen:     NewIDGenerator(),
 		protoSize: p.PrototypeChannel * p.PrototypeHeight * p.PrototypeWeight,
+		bufPool:   NewBufferPool(),
 	}
 }
 
@@ -298,6 +303,10 @@ func (y *YOLOv5Seg) SegmentMask(detectObjs DetectionResult,
 	// handle segment masks
 	segData := detectObjs.(YOLOv5SegResult).GetSegmentData()
 	boxesNum := segData.boxesNum
+	modelH := int(segData.data.height)
+	modelW := int(segData.data.width)
+
+	y.initBufferPool(segData, resizer)
 
 	// C code does not use USE_FP_RESIZE as uint8 is faster via CPU calculation
 	// than using NPU
@@ -307,41 +316,113 @@ func (y *YOLOv5Seg) SegmentMask(detectObjs DetectionResult,
 	// greater than 6 boxes. the parallel version has a negative consequence
 	// in that it effects the performance of the resizeByOpenCVUint8() call
 	// afterwards due to the overhead of the goroutines being cleaned up.
-	var matmulOut []uint8
+	matmulOut := y.bufPool.Get(bufMatMul,
+		boxesNum*y.Params.PrototypeHeight*y.Params.PrototypeWeight)
+	defer y.bufPool.Put(bufMatMul, matmulOut)
+
 	if boxesNum > 6 {
-		matmulOut = matmulUint8Parallel(segData.data, boxesNum,
-			y.Params.PrototypeChannel, y.Params.PrototypeHeight,
-			y.Params.PrototypeWeight)
+		matmulUint8Parallel(
+			segData.data, boxesNum,
+			y.Params.PrototypeChannel,
+			y.Params.PrototypeHeight,
+			y.Params.PrototypeWeight,
+			matmulOut,
+		)
 	} else {
-		matmulOut = matmulUint8(segData.data, boxesNum,
-			y.Params.PrototypeChannel, y.Params.PrototypeHeight,
-			y.Params.PrototypeWeight)
+		matmulUint8(
+			segData.data, boxesNum,
+			y.Params.PrototypeChannel,
+			y.Params.PrototypeHeight,
+			y.Params.PrototypeWeight,
+			matmulOut,
+		)
 	}
 
-	// resize the tensor mask outputs to (boxes_num, model_in_width, model_in_height)
-	segMask := make([]uint8, boxesNum*int(segData.data.height*segData.data.width))
+	// resize each proto‑mask to full model input dims,
+	// but only in its bounding‑box ROI, merging into allMaskInOne
+	allMask := y.bufPool.Get(bufAllMask, modelH*modelW)
+	defer y.bufPool.Put(bufAllMask, allMask)
 
-	resizeByOpenCVUint8(matmulOut, y.Params.PrototypeWeight, y.Params.PrototypeHeight,
-		boxesNum, segMask, int(segData.data.width), int(segData.data.height))
+	protoH := y.Params.PrototypeHeight
+	protoW := y.Params.PrototypeWeight
 
-	// crop mask takes all segment makes from inference and combines them into a single mask
-	allMaskInOne := make([]uint8, segData.data.height*segData.data.width)
-	cropMaskWithIDUint8(segMask, allMaskInOne, segData.filterBoxesByNMS, boxesNum,
-		int(segData.data.height), int(segData.data.width), []int{})
+	// temp buffer for one‑box resize
+	segMaskBuf := y.bufPool.Get(bufSegMask, modelH*modelW)
+	defer y.bufPool.Put(bufSegMask, segMaskBuf)
 
-	// get real mask
-	croppedHeight := int(segData.data.height) - resizer.YPad()*2
-	croppedWidth := int(segData.data.width) - resizer.XPad()*2
+	for b := 0; b < boxesNum; b++ {
+		// get the b'th proto mask slice
+		start := b * protoH * protoW
+		protoSlice := matmulOut[start : start+protoH*protoW]
 
-	croppedSegMask := make([]uint8, croppedHeight*croppedWidth)
-	realSegMask := make([]uint8, resizer.SrcHeight()*resizer.SrcWidth())
+		// resize that one box’s mask to the full model dims
+		// not just ROI—so segReverse’s cropping lines up
+		resizeByOpenCVUint8(
+			protoSlice, protoW, protoH,
+			1,
+			segMaskBuf, modelW, modelH,
+		)
 
-	segReverse(allMaskInOne, croppedSegMask, realSegMask,
-		int(segData.data.height), int(segData.data.width), croppedHeight, croppedWidth,
-		resizer.SrcHeight(), resizer.SrcWidth(), resizer.YPad(), resizer.XPad(),
+		// merge just ROI pixels into allMask
+		// filterBoxesByNMS is in model coords
+		x1 := segData.filterBoxesByNMS[b*4+0]
+		y1 := segData.filterBoxesByNMS[b*4+1]
+		x2 := segData.filterBoxesByNMS[b*4+2]
+		y2 := segData.filterBoxesByNMS[b*4+3]
+
+		// clamp
+		if x1 < 0 {
+			x1 = 0
+		}
+
+		if y1 < 0 {
+			y1 = 0
+		}
+
+		if x2 > modelW {
+			x2 = modelW
+		}
+
+		if y2 > modelH {
+			y2 = modelH
+		}
+
+		id := uint8(b + 1) // assign unique id to object
+
+		for yy := y1; yy < y2; yy++ {
+			base := yy*modelW + x1
+
+			for xx := x1; xx < x2; xx++ {
+				if segMaskBuf[yy*modelW+xx] != 0 {
+					allMask[base+xx-x1] = id
+				}
+			}
+		}
+	}
+
+	// do segReverse to produce the final real‑image mask
+	croppedH := modelH - resizer.YPad()*2
+	croppedW := modelW - resizer.XPad()*2
+	realH := resizer.SrcHeight()
+	realW := resizer.SrcWidth()
+
+	cropBuf := y.bufPool.Get(bufCrop, croppedH*croppedW)
+	defer y.bufPool.Put(bufCrop, cropBuf)
+
+	// allocate final mask right before return
+	realMask := make([]uint8, realH*realW)
+
+	segReverse(
+		allMask,  // model‑input mask
+		cropBuf,  // temp cropped
+		realMask, // output
+		modelH, modelW,
+		croppedH, croppedW,
+		realH, realW,
+		resizer.YPad(), resizer.XPad(),
 	)
 
-	return SegMask{realSegMask}
+	return SegMask{realMask}
 }
 
 // TrackMask creates segment mask data for tracked objects
@@ -349,27 +430,27 @@ func (y *YOLOv5Seg) TrackMask(detectObjs DetectionResult,
 	trackObjs []*tracker.STrack, resizer *preprocess.Resizer) SegMask {
 
 	// handle segment masks
-	detectResults := detectObjs.(YOLOv5SegResult).GetDetectResults()
+	detRes := detectObjs.(YOLOv5SegResult).GetDetectResults()
 	segData := detectObjs.(YOLOv5SegResult).GetSegmentData()
 	boxesNum := segData.boxesNum
+	modelH := int(segData.data.height)
+	modelW := int(segData.data.width)
 
 	// the detection objects and tracked objects can be different, so we need
 	// to adjust the segment mask to only have tracked object masks and strip
 	// out the non-used ones
-	trackObjIDs := make([]int64, 0)
+	keep := make([]bool, boxesNum)
 
-	for _, trackObj := range trackObjs {
-		trackObjIDs = append(trackObjIDs, trackObj.GetDetectionID())
-	}
-
-	// go through the detection results to find the object ID's we need to strip out
-	stripObjs := make([]int, 0)
-
-	for i, detResult := range detectResults {
-		if !int64InSlice(detResult.ID, trackObjIDs) {
-			stripObjs = append(stripObjs, i)
+	for _, to := range trackObjs {
+		for i, dr := range detRes {
+			if dr.ID == to.GetDetectionID() {
+				keep[i] = true
+				break
+			}
 		}
 	}
+
+	y.initBufferPool(segData, resizer)
 
 	// C code does not use USE_FP_RESIZE as uint8 is faster via CPU calculation
 	// than using NPU
@@ -379,41 +460,114 @@ func (y *YOLOv5Seg) TrackMask(detectObjs DetectionResult,
 	// greater than 6 boxes. the parallel version has a negative consequence
 	// in that it effects the performance of the resizeByOpenCVUint8() call
 	// afterwards due to the overhead of the goroutines being cleaned up.
-	var matmulOut []uint8
+	matmulOut := y.bufPool.Get(bufMatMul,
+		boxesNum*y.Params.PrototypeHeight*y.Params.PrototypeWeight)
+	defer y.bufPool.Put(bufMatMul, matmulOut)
+
 	if boxesNum > 6 {
-		matmulOut = matmulUint8Parallel(segData.data, boxesNum,
-			y.Params.PrototypeChannel, y.Params.PrototypeHeight,
-			y.Params.PrototypeWeight)
+		matmulUint8Parallel(
+			segData.data, boxesNum,
+			y.Params.PrototypeChannel,
+			y.Params.PrototypeHeight,
+			y.Params.PrototypeWeight,
+			matmulOut,
+		)
 	} else {
-		matmulOut = matmulUint8(segData.data, boxesNum,
-			y.Params.PrototypeChannel, y.Params.PrototypeHeight,
-			y.Params.PrototypeWeight)
+		matmulUint8(
+			segData.data, boxesNum,
+			y.Params.PrototypeChannel,
+			y.Params.PrototypeHeight,
+			y.Params.PrototypeWeight,
+			matmulOut,
+		)
 	}
 
-	// resize the tensor mask outputs to (boxes_num, model_in_width, model_in_height)
-	segMask := make([]uint8, boxesNum*int(segData.data.height*segData.data.width))
+	// prepare combined mask at model resolution
+	allMask := y.bufPool.Get(bufAllMask, modelH*modelW)
+	defer y.bufPool.Put(bufAllMask, allMask)
 
-	resizeByOpenCVUint8(matmulOut, y.Params.PrototypeWeight, y.Params.PrototypeHeight,
-		boxesNum, segMask, int(segData.data.width), int(segData.data.height))
+	protoH := y.Params.PrototypeHeight
+	protoW := y.Params.PrototypeWeight
 
-	// crop mask takes all segment makes from inference and combines them into a single mask
-	allMaskInOne := make([]uint8, segData.data.height*segData.data.width)
-	cropMaskWithIDUint8(segMask, allMaskInOne, segData.filterBoxesByNMS, boxesNum,
-		int(segData.data.height), int(segData.data.width), stripObjs)
+	// temp buffer for per‑object resize
+	segMaskBuf := y.bufPool.Get(bufSegMask, modelH*modelW)
+	defer y.bufPool.Put(bufSegMask, segMaskBuf)
 
-	// get real mask
-	croppedHeight := int(segData.data.height) - resizer.YPad()*2
-	croppedWidth := int(segData.data.width) - resizer.XPad()*2
+	for b := 0; b < boxesNum; b++ {
+		// skip objects we are not tracking
+		if !keep[b] {
+			continue
+		}
 
-	croppedSegMask := make([]uint8, croppedHeight*croppedWidth)
-	realSegMask := make([]uint8, resizer.SrcHeight()*resizer.SrcWidth())
+		// resize proto mask[b] to model dims
+		start := b * protoH * protoW
+		protoSlice := matmulOut[start : start+protoH*protoW]
 
-	segReverse(allMaskInOne, croppedSegMask, realSegMask,
-		int(segData.data.height), int(segData.data.width), croppedHeight, croppedWidth,
-		resizer.SrcHeight(), resizer.SrcWidth(), resizer.YPad(), resizer.XPad(),
+		resizeByOpenCVUint8(
+			protoSlice, protoW, protoH,
+			1,
+			segMaskBuf, modelW, modelH,
+		)
+
+		// merge only within ROI
+		x1 := segData.filterBoxesByNMS[b*4+0]
+		y1 := segData.filterBoxesByNMS[b*4+1]
+		x2 := segData.filterBoxesByNMS[b*4+2]
+		y2 := segData.filterBoxesByNMS[b*4+3]
+
+		// clamp
+		if x1 < 0 {
+			x1 = 0
+		}
+
+		if y1 < 0 {
+			y1 = 0
+		}
+
+		if x2 > modelW {
+			x2 = modelW
+		}
+
+		if y2 > modelH {
+			y2 = modelH
+		}
+
+		id := uint8(b + 1) // assign unique id to object
+
+		for yy := y1; yy < y2; yy++ {
+			base := yy*modelW + x1
+
+			for xx := x1; xx < x2; xx++ {
+				if segMaskBuf[yy*modelW+xx] != 0 {
+					allMask[base+xx-x1] = id
+				}
+			}
+		}
+	}
+
+	// reverse to original image size
+	croppedH := modelH - resizer.YPad()*2
+	croppedW := modelW - resizer.XPad()*2
+	realH := resizer.SrcHeight()
+	realW := resizer.SrcWidth()
+
+	cropBuf := y.bufPool.Get(bufCrop, croppedH*croppedW)
+	defer y.bufPool.Put(bufCrop, cropBuf)
+
+	// allocate final mask right before return
+	realMask := make([]uint8, realH*realW)
+
+	segReverse(
+		allMask,
+		cropBuf,
+		realMask,
+		modelH, modelW,
+		croppedH, croppedW,
+		realH, realW,
+		resizer.YPad(), resizer.XPad(),
 	)
 
-	return SegMask{realSegMask}
+	return SegMask{realMask}
 }
 
 // processStride processes the given stride
@@ -511,4 +665,32 @@ func (y *YOLOv5Seg) processStride(outputs *rknnlite.Outputs, inputID int,
 	}
 
 	return validCount
+}
+
+// initBufferPool initializes the buffer pool
+func (y *YOLOv5Seg) initBufferPool(segData SegmentData,
+	resizer *preprocess.Resizer) {
+
+	if y.bufPoolInit {
+		return
+	}
+
+	modelH := int(segData.data.height)
+	modelW := int(segData.data.width)
+
+	y.bufPool.Create(bufMatMul,
+		y.Params.MaxObjectNumber*y.Params.PrototypeHeight*y.Params.PrototypeWeight)
+
+	y.bufPool.Create(bufSegMask,
+		y.Params.MaxObjectNumber*int(segData.data.height*segData.data.width))
+
+	y.bufPool.Create(bufAllMask,
+		int(segData.data.height*segData.data.width))
+
+	croppedH := modelH - resizer.YPad()*2
+	croppedW := modelW - resizer.XPad()*2
+
+	y.bufPool.Create(bufCrop, croppedH*croppedW)
+
+	y.bufPoolInit = true
 }


### PR DESCRIPTION
Refactored Yolov5/v8 Segmentation code to speed up post processing and mask rendering.

* Added generic buffer‑pooling via a segBufferPool map of named pools to reuse []uint8 buffers of arbitrary lengths.

* Eliminated all per‑frame make([]uint8,…) calls for intermediate arrays (matmulOut, segMask, allMask, cropBuf) by reusing pooled buffers, collapsing GC pauses and heap churn.

* Optimized matmul to write directly into a caller‑provided slice (from the pool), with both a straight‐line and a stride‐based parallel version—no allocations inside the hot loops.

* ROI‑based merging of per‑object masks at the model‑input resolution:

* Resize each object’s prototype mask once to the full model dims,

* Only walk the pixels inside that object’s bounding‐box ROI to merge its ID into a single allMask array,

* Replacing costly global segMask + cropMaskWithIDUint8 passes.

* One‑time segReverse at the end to map the combined model‑input mask back to the original image size, preserving padding removal and artifact filtering exactly as before.

The above has resulted in the following performance enhancement.

| Model|	Average Total Time	|Inference	|Post Processing	|Rendering|
| --- | --- | --- | --- | --- |
| YOLOv5s-seg - BEFORE | 207.5ms            | 57.0ms    | 107.6ms         | 75.9ms    |
 YOLOv5s-seg - AFTER | 106.1ms            | 45.0ms    | 68.4ms          | 4.8ms     |
| YOLOv8s-seg  - BEFORE | 232.5ms            | 67.9ms    | 113.3ms         | 73.4ms    |
| YOLOv8s-seg - AFTER | 122.6ms            | 52.7ms    | 69.3ms          | 4.3ms     |