### PR TITLE
Support rk35xx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
            mkdir -p example/data
            curl -L \
-             https://raw.githubusercontent.com/swdee/go-rknnlite-data/master/mobilenet_v1-rk3588.rknn \
+             https://raw.githubusercontent.com/swdee/go-rknnlite-data/master/models/rk3588/mobilenet_v1-rk3588.rknn \
              -o example/data/mobilenet_v1-rk3588.rknn
            curl -L \
              https://raw.githubusercontent.com/swdee/go-rknnlite-data/master/cat_224x224.jpg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,9 +94,11 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 # Set working directory
 WORKDIR /go/src/versiontest
 
-# If a go.mod doesn't already exist, initialize a temporary module.
-# (This helps when running "go get" so that a module context is present.)
-RUN go mod init tmp || true
+# Use the go.mod file of go-rknnlite so we can install its dependencies
+COPY go.mod go.sum ./
+
+# Fetch go-rknnlite's dependencies
+RUN go mod download
 
 # Set the GoCV version to build (adjust as needed)
 ENV GOCV_VERSION=v0.41.0

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ C API interface.  It aims to provide lite bindings in the spirit of the closed s
 Python lite bindings used for running AI Inference models on the Rockchip NPU 
 via the RKNN software stack.
 
-These bindings are made to work with Rockchips [RK35xx series](https://www.rock-chips.com/a/en/products/RK35_Series/) of processors, 
-specifcally the RK3562, RK3566, RK3568, RK3576, RK3582, and RK3588.
+These bindings are made to work with Rockchips [RK35xx series](https://www.rock-chips.com/a/en/products/RK35_Series/) of processors,
+specifically the RK3562, RK3566, RK3568, RK3576, RK3582, and RK3588.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or to try the examples clone the git code and data repositories.
 ```
 git clone https://github.com/swdee/go-rknnlite.git
 cd go-rknnlite/example
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Then refer to the Readme files for each example to run on command line.

--- a/cpuaffinity.go
+++ b/cpuaffinity.go
@@ -2,6 +2,7 @@ package rknnlite
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -11,16 +12,75 @@ const (
 	RK3588FastCores = uintptr(0b11110000)
 	// RK3588SlowCores is the cpu affinity mask of the efficient cortex A55 cores 0-3
 	RK3588SlowCores = uintptr(0b00001111)
-	// RK3588Allcores is the cpu affinity mask for all cortext A76 and A55 cores 0-7
+	// RK3588Allcores is the cpu affinity mask for all cortex A76 and A55 cores 0-7
 	RK3588AllCores = uintptr(0b11111111)
 
 	// RK3582FastCores is the cpu affinity mask of the fast cortex A76 cores 4-5
 	RK3582FastCores = uintptr(0b00110000)
 	// RK3582SlowCores is the cpu affinity mask of the efficient cortex A55 cores 0-3
 	RK3582SlowCores = uintptr(0b00001111)
-	// RK3582Allcores is the cpu affinity mask for all cortext A76 and A55 cores 0-5
+	// RK3582Allcores is the cpu affinity mask for all cortex A76 and A55 cores 0-5
 	RK3582AllCores = uintptr(0b00111111)
+
+	// RK3576FastCores is the cpu affinity mask of the fast cortex A72 cores 4-7
+	RK3576FastCores = uintptr(0b11110000)
+	// RK3576SlowCores is the cpu affinity mask of the efficient cortex A53 cores 0-3
+	RK3576SlowCores = uintptr(0b00001111)
+	// RK3576Allcores is the cpu affinity mask for all cortex A72 and A53 cores 0-7
+	RK3576AllCores = uintptr(0b11111111)
+
+	// RK3568AllCores is the cpu affinity mask of all cortex A55 (2Ghz) cores 0-3
+	RK3568AllCores = uintptr(0b00001111)
+
+	// RK3566AllCores is the cpu affinity mask of all cortex A55 (1.6Ghz) cores 0-3
+	RK3566AllCores = uintptr(0b00001111)
+
+	// RK3562AllCores is the cpu affinity mask of all cortex A53 cores 0-3
+	RK3562AllCores = uintptr(0b00001111)
 )
+
+// CoreType specifies the CPU core type
+type CoreType int
+
+const (
+	FastCores CoreType = 0
+	SlowCores CoreType = 1
+	AllCores  CoreType = 2
+)
+
+// coreMaskList defines a list of CPU core masks for lookup by key
+var coreMaskList = map[string]map[CoreType]uintptr{
+	"rk3562": {
+		SlowCores: RK3562AllCores,
+		FastCores: RK3562AllCores,
+		AllCores:  RK3562AllCores,
+	},
+	"rk3566": {
+		SlowCores: RK3566AllCores,
+		FastCores: RK3566AllCores,
+		AllCores:  RK3566AllCores,
+	},
+	"rk3568": {
+		SlowCores: RK3568AllCores,
+		FastCores: RK3568AllCores,
+		AllCores:  RK3568AllCores,
+	},
+	"rk3576": {
+		SlowCores: RK3576SlowCores,
+		FastCores: RK3576FastCores,
+		AllCores:  RK3576AllCores,
+	},
+	"rk3582": {
+		SlowCores: RK3582SlowCores,
+		FastCores: RK3582FastCores,
+		AllCores:  RK3582AllCores,
+	},
+	"rk3588": {
+		SlowCores: RK3588SlowCores,
+		FastCores: RK3588FastCores,
+		AllCores:  RK3588AllCores,
+	},
+}
 
 // SetCPUAffinity sets the CPU Affinity mask of the program to run on the specified
 // cores
@@ -62,4 +122,29 @@ func CPUCoreMask(cores []int) uintptr {
 	}
 
 	return mask
+}
+
+// SetCPUAffinityByPlatform sets the CPU Affinity mask of the program to run
+// on the specified CPU cores based on the given platform string of
+// rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588
+func SetCPUAffinityByPlatform(platform string, ct CoreType) error {
+
+	var useCores uintptr
+	matched := false
+
+	platform = strings.TrimSpace(platform)
+	platform = strings.ToLower(platform)
+
+	if platform, ok := coreMaskList[platform]; ok {
+		if coretype, ok := platform[ct]; ok {
+			useCores = coretype
+			matched = true
+		}
+	}
+
+	if !matched {
+		return fmt.Errorf("unknown platform: %s", platform)
+	}
+
+	return SetCPUAffinity(useCores)
 }

--- a/example/README.md
+++ b/example/README.md
@@ -10,16 +10,61 @@ Note that detection results vary depending on the YOLO version.
 
 The `data/palace.jpg` image file was used for benchmarking.
 
+
+![Average Time Graph](https://github.com/swdee/go-rknnlite-data/raw/master/yolobench/avg-time-graph.png)
+
+
+### rk3588
+
+Results for the rk3588 with 6 TOPS three core NPU operating at 1Ghz.
+
+
 | Model        | Average Total Time | Inference | Post Processing | Rendering |
 |--------------|--------------------|-----------|-----------------|-----------|
-| YOLOv5s      | 29.6ms             | 33.6ms    | 1.0ms           | 4.4ms     |
-| YOLOv8s      | 44.8ms             | 47.5ms    | 5.0ms           | 4.2ms     |
-| YOLOv10s     | 49.4ms             | 57.1ms    | 2.9ms           | 4.1ms     |
-| YOLOXs       | 42.4ms             | 48.7ms    | 0.5ms           | 5.5ms     |
-| YOLOv11s     | 48.1ms             | 55.1ms    | 2.3ms           | 4.1ms     |
-| YOLOv8n-pose | 47.5ms             | 54.1ms    | 1.0ms           | 3.0ms     |
-| YOLOv5s-seg  | 106.1ms            | 45.0ms    | 68.4ms          | 4.8ms     |
-| YOLOv8s-seg  | 122.6ms            | 52.7ms    | 69.3ms          | 4.3ms     |
+| YOLOv5s      | 30.2ms             | 34.9ms    | 0.4ms           | 2.2ms     |
+| YOLOv8s      | 39.6ms             | 41.5ms    | 2.4ms           | 2.3ms     |
+| YOLOv10s     | 48.8ms             | 47.5ms    | 1.3ms           | 2.0ms     |
+| YOLOXs       | 38.4ms             | 39.4ms    | 0.2ms           | 2.6ms     |
+| YOLOv11s     | 46.8ms             | 49.0ms    | 0.9ms           | 1.7ms     |
+| YOLOv8n-pose | 37.8ms             | 37.3ms    | 0.5ms           | 1.4ms     |
+| YOLOv5s-seg  | 108.1ms            | 46.0ms    | 64.6ms          | 4.4ms     |
+| YOLOv8s-seg  | 122.0ms            | 53.0ms    | 72.4ms          | 4.3ms     |
+
+
+### rk3576
+
+Results for the rk3576 with 6 TOPS two core NPU operating at 950Mhz.
+
+
+| Model        | Average Total Time | Inference | Post Processing | Rendering |
+|--------------|--------------------|-----------|-----------------|-----------|
+| YOLOv5s      | 29.2ms             | 48.3ms    | 1.0ms           | 3.8ms     |
+| YOLOv8s      | 43.4ms             | 60.6ms    | 4.1ms           | 4.0ms     |
+| YOLOv10s     | 49.2ms             | 68.2ms    | 2.3ms           | 3.5ms     |
+| YOLOXs       | 37.9ms             | 56.2ms    | 0.6ms           | 4.7ms     |
+| YOLOv11s     | 38.4ms             | 70.1ms    | 2.0ms           | 3.4ms     |
+| YOLOv8n-pose | 33.9ms             | 49.5ms    | 0.9ms           | 2.3ms     |
+| YOLOv5s-seg  | 151.9ms            | 65.9ms    | 95.7ms          | 7.0ms     |
+| YOLOv8s-seg  | 154.2ms            | 78.7ms    | 126.7ms         | 8.2ms     |
+
+
+### rk3566
+
+Results for the rk3566 with 1 TOPS single core NPU operating at 900Mhz.
+
+
+| Model        | Average Total Time | Inference | Post Processing | Rendering |
+|--------------|--------------------|-----------|-----------------|-----------|
+| YOLOv5s      | 70.2ms             | 70.4ms    | 2.4ms           | 7.2ms     |
+| YOLOv8s      | 95.5ms             | 84.6ms    | 10.3ms          | 7.6ms     |
+| YOLOv10s     | 122.3ms            | 116.3ms   | 7.6ms           | 8.1ms     |
+| YOLOXs       | 83.0ms             | 78.9ms    | 1.7ms           | 9.8ms     |
+| YOLOv11s     | 117.3ms            | 117.6ms   | 4.9ms           | 7.1ms     |
+| YOLOv8n-pose | 59.8ms             | 62.2ms    | 1.6ms           | 4.5ms     |
+| YOLOv5s-seg  | 433.64ms           | 95.7ms    | 349.7ms         | 20.0ms    |
+| YOLOv8s-seg  | 420.8ms            | 110.7ms   | 312.3ms         | 19.7ms    |
+
+
 
 The Inference, Post Processing, and Rendering columns show how processing time
 is split across the Total Time.   These figures are derived from the first

--- a/example/alpr/README.md
+++ b/example/alpr/README.md
@@ -35,7 +35,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the ALPR example.

--- a/example/alpr/README.md
+++ b/example/alpr/README.md
@@ -18,7 +18,8 @@ Use the `ultralytics/engine/exporter.py` script in this repository to convert th
 PyTorch model to ONNX.
 
 Then compile from ONNX to RKNN using the [conversion script](https://github.com/airockchip/rknn_model_zoo/blob/main/examples/yolov8/python/convert.py)
-from the Model Zoo.
+from the Model Zoo making sure to provide it a subset of images it was trained
+on for the quantization process.
 
 The LPRNet model used from the RKNN Model Zoo is for Chinese License Plates.
 I don't think it's very good, the input size of 94x24 pixels is too small and 
@@ -38,17 +39,17 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the ALPR example.
+Run the ALPR example on rk3588 or replace with your Platform model.
 ```
 cd example/alpr
-go run alpr.go
+go run alpr.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Model first run speed: YOLO inference=25.336366ms, YOLO post processing=137.371µs, Plate recognition=7.908609ms, Plate post processing=456.737µs, Total time=33.839083ms
+Model first run speed: YOLO inference=22.395264ms, YOLO post processing=126.581µs, Plate recognition=4.295597ms, Plate post processing=437.202µs, Total time=27.254644ms
 Saved object detection result to ../data/car-cn-alpr-out.jpg
-Benchmark time=1.629993653s, count=50, average total time=32.599873ms
+Benchmark time=2.976581181s, count=100, average total time=29.765811ms
 done
 ```
 
@@ -61,19 +62,21 @@ license plate detection.
 See help for passing parameters to try your own images.
 ```
 $ go run alpr.go -h
-Usage of /tmp/go-build506851743/b001/exe/alpr:
+Usage of /tmp/go-build3203844595/b001/exe/alpr:
   -f string
         The TTF font to use (default "../data/fzhei-b01s-regular.ttf")
   -i string
         Image file to run object detection on (default "../data/car-cn.jpg")
   -l string
-        RKNN compiled LPRNet model file (default "../data/lprnet-rk3588.rknn")
+        RKNN compiled LPRNet model file (default "../data/models/rk3588/lprnet-rk3588.rknn")
   -m string
-        RKNN compiled YOLO model file (default "../data/lpd-yolov8n-640-640-rk3588.rknn")
+        RKNN compiled YOLO model file (default "../data/models/rk3588/lpd-yolov8n-rk3588.rknn")
   -o string
         The output JPG file with object detection markers (default "../data/car-cn-alpr-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
   -t string
-        The text drawing mode [cn|en] (default "cn")
+        The text drawing mode [cn|en] (default "cn")        
 ```
 
 ### Docker
@@ -91,7 +94,21 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/alpr/alpr.go
+  go run ./example/alpr/alpr.go -p rk3588
 ```
 
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 2.97s          | 29.76ms                          |
+| rk3576   | 3.20s          | 31.83ms                          |
+| rk3566   | 6.93s          | 69.36ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.
 

--- a/example/lprnet/README.md
+++ b/example/lprnet/README.md
@@ -8,7 +8,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the LPRNet example.

--- a/example/lprnet/README.md
+++ b/example/lprnet/README.md
@@ -11,31 +11,46 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the LPRNet example.
+Run the LPRNet example on rk3588 or replace with your Platform model.
 ```
 cd example/lprnet
-go run lprnet.go
+go run lprnet.go -p rk3588
 ```
 
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 1
 Input tensors:
   index=0, name=input, n_dims=4, dims=[1, 24, 94, 3], n_elems=6768, size=6768, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=0, scale=0.007843
 Output tensors:
-  index=0, name=output, n_dims=3, dims=[1, 68, 18, 0], n_elems=1224, size=1224, fmt=UNDEFINED, type=INT8, qnt_type=AFFINE, zp=47, scale=0.911201
-Model first run speed: inference=7.787585ms, post processing=25.374µs, total time=7.812959ms
+  index=0, name=output, n_dims=3, dims=[1, 68, 18, 0], n_elems=1224, size=1224, fmt=UNDEFINED, type=INT8, qnt_type=AFFINE, zp=50, scale=0.643529
+Model first run speed: inference=4.203128ms, post processing=30.916µs, total time=4.234044ms
 License plate recognition result: 湘F6CL03
-Benchmark time=61.070751ms, count=10, average total time=6.107075ms
+Benchmark time=350.625899ms, count=100, average total time=3.506258ms
 done
 ```
 
 To use your own RKNN compiled model and images.
 ```
-go run lprnet.go -m <RKNN model file> -i <image file>
+go run lprnet.go -m <RKNN model file> -i <image file> -p <platform>
 ```
+
+
+See the help for command line parameters.
+```
+$ go run lprnet.go --help
+
+Usage of /tmp/go-build233788912/b001/exe/lprnet:
+  -i string
+        Image file to run inference on (default "../data/lplate.jpg")
+  -m string
+        RKNN compiled model file (default "../data/models/rk3588/lprnet-rk3588.rknn")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
+```
+
 
 ### Docker
 
@@ -52,7 +67,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/lprnet/lprnet.go
+  go run ./example/lprnet/lprnet.go -p rk3588
 ```
 
 
@@ -62,6 +77,23 @@ This example makes use of the [Chinese License Plate Recognition LPRNet](https:/
 You can train your own LPRNet's for other countries but need to initialize
 the `postprocess.NewLPRNet` with your specific `LPRNetParams` containing the
 maximum length of your countries number plates and character set used.
+
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 0.35s          | 3.50ms                           |
+| rk3576   | 0.49s          | 4.96ms                           |
+| rk3566   | 1.63s          | 16.32ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.
+
 
 
 ## Background

--- a/example/mobilenet/README.md
+++ b/example/mobilenet/README.md
@@ -10,10 +10,10 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the MobileNet example.
+Run the MobileNet example on RK3588 or replace with your Platform model.
 ```
 cd example/mobilenet/
-go run mobilenet.go 
+go run mobilenet.go -p rk3588
 ```
 
 This will result in the output of:
@@ -35,7 +35,20 @@ done
 
 To use your own RKNN compiled model and images.
 ```
-go run mobilenet.go -m <RKNN model file> -i <image file>
+go run mobilenet.go -m <RKNN model file> -i <image file> -p <platform>
+```
+
+See the help for command line parameters.
+```
+$ go run mobilenet.go --help
+
+Usage of /tmp/go-build2453632432/b001/exe/mobilenet:
+  -i string
+        Image file to run inference on (default "../data/cat_224x224.jpg")
+  -m string
+        RKNN compiled model file (default "../data/models/rk3588/mobilenet_v1-rk3588.rknn")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
 ```
 
 ### Docker
@@ -53,7 +66,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/mobilenet/mobilenet.go
+  go run ./example/mobilenet/mobilenet.go -p rk3588
 ```
 
 

--- a/example/mobilenet/README.md
+++ b/example/mobilenet/README.md
@@ -7,7 +7,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the MobileNet example.

--- a/example/mobilenet/README.md
+++ b/example/mobilenet/README.md
@@ -10,7 +10,7 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the MobileNet example on RK3588 or replace with your Platform model.
+Run the MobileNet example on rk3588 or replace with your Platform model.
 ```
 cd example/mobilenet/
 go run mobilenet.go -p rk3588

--- a/example/mobilenet/mobilenet.go
+++ b/example/mobilenet/mobilenet.go
@@ -10,6 +10,7 @@ import (
 	"image"
 	"log"
 	"os"
+	"strings"
 )
 
 func main() {
@@ -17,18 +18,25 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/mobilenet_v1-rk3588.rknn", "RKNN compiled model file")
+	modelFile := flag.String("m", "../data/models/rk3588/mobilenet_v1-rk3588.rknn", "RKNN compiled model file")
 	imgFile := flag.String("i", "../data/cat_224x224.jpg", "Image file to run inference on")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)

--- a/example/pool/README.md
+++ b/example/pool/README.md
@@ -37,13 +37,15 @@ Command line Usage.
 ```
 $ go run pool.go -h
 
-Usage of /tmp/go-build3261134608/b001/exe/pool:
+Usage of /tmp/go-build1518837318/b001/exe/pool:
   -c string
         CPU Affinity, run on [fast|slow] CPU cores (default "fast")
   -d string
         A directory of images to run inference on (default "../data/imagenet/")
   -m string
-        RKNN compiled model file (default "../data/mobilenet_v1-rk3588.rknn")
+        RKNN compiled model file (default "../data/models/rk3588/mobilenet_v1-rk3588.rknn")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
   -q    Run in quiet mode, don't display individual inference results
   -r int
         Repeat processing image directory the specified number of times, use this if you don't have enough images (default 1)
@@ -51,20 +53,25 @@ Usage of /tmp/go-build3261134608/b001/exe/pool:
         Size of RKNN runtime pool, choose 1, 2, 3, or multiples of 3 (default 1)
 ```
 
-To run the example pool using 3 Runtimes in the pool and downloaded data.
+To run the example pool using 3 Runtimes in the pool and downloaded data.  Make
+sure you replace the `<platform>` with your Rockchip model, eg: `rk3588`.
 ```
 cd example/pool/
-go run pool.go -q -s 3 -r 4
+go run pool.go -q -s 3 -r 4 -p <platform>
 ```
 
 Example summary.
 ```
 Running...
-Processed 4000 images in 9.36881374s, average inference per image is 2.34ms
+Processed 4000 images in 9.61513744s, average inference per image is 2.40ms
 ```
 
+### Pool Multiples
+
 When selecting the number of Runtimes to initialize the pool with select 1, 2, 3, or
-a multiple of 3 to spread them across all three NPU cores.
+a multiple of 3 to spread them across all three NPU cores on the rk358x series.
+
+The rk3576 only has two NPU cores, so select multiples for 2.
 
 
 ### Docker
@@ -82,7 +89,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/pool/pool.go -q -s 3 -r 4
+  go run ./example/pool/pool.go -q -s 3 -r 4 -p <platform>
 ```
 
 
@@ -90,27 +97,62 @@ docker run --rm \
 
 ## Benchmarks
 
-For an EfficentNet-Lite0 Model we achieve the following average inference times
+For the [MobileNet-v1 model](../mobilenet/) we achieve the following average inference times
 for the number of Runtimes in the Pool processing 8000 images.
 
+Note that the more Runtimes created in the pool the more memory is needed for 
+each instance of the Model loaded.
+
+
+### rk3588
+
+Results for the rk3588 with 6 TOPS three core NPU operating at 1Ghz.
 
 | Number of Runtimes | Execution Time | Core Saturation      | Average Inference Time Per Image |
 | ---- |----------------|----------------------|----------------------------------|
-| 1 | 57.21s         | ~35% core saturation | 7.15ms                            |
-| 2 | 29.59s         | ~35% core saturation | 3.70ms                           |
-| 3 | 20.46s         | ~35% core saturation | 2.56ms                           |
-| 6 | 12.12s         | ~60% core saturation | 1.52ms                           |
-| 9 | 10.01s         | ~74% core saturation | 1.25ms                           |
-| 12 | 9.55s          | ~80% core saturation | 1.19ms                           |
-| 15 | 9.36s          | ~80% core saturation | 1.17ms                           |
+| 1 | 61.82s         | ~35% core saturation | 7.73ms                           |
+| 2 | 27.94s         | ~35% core saturation | 3.49ms                           |
+| 3 | 18.50s         | ~35% core saturation | 2.31ms                           |
+| 6 | 12.18s         | ~60% core saturation | 1.52ms                           |
+| 9 | 9.51s          | ~74% core saturation | 1.19ms                           |
+| 12 | 9.02s          | ~80% core saturation | 1.13ms                           |
+| 15 | 8.75s          | ~80% core saturation | 1.09ms                           |
 
 
 Core saturation peaks around 80% across all three cores so going beyond 9 Runtimes
 has diminishing returns.   
 
-Note that the more Runtimes created the more memory is needed for each instance
-of the Model loaded.
 
-Previously we achieved ~60% core saturation but through the use of CPU Affinity
-and running this program on the fast Cortex-A76 cores only we can further
-saturate the NPU cores to ~80%.
+
+### rk3576
+
+Results for the rk3576 with 6 TOPS two core NPU operating at 950Mhz.
+
+
+| Number of Runtimes | Execution Time | Core Saturation      | Average Inference Time Per Image |
+|--------------------|----------------|----------------------|----------------------------------|
+| 1                  | 94.06s         | ~30% core saturation | 11.76ms                          |
+| 2                  | 42.60s         | ~24% core saturation | 5.33ms                           |
+| 4                  | 23.53s         | ~37% core saturation | 2.94ms                           |
+| 6                  | 17.80s         | ~48% core saturation | 2.23ms                           |
+| 8                  | 14.98s         | ~58% core saturation | 1.87ms                           |
+| 10                 | 14.11s         | ~62% core saturation | 1.76ms                           |
+| 12                 | 13.70s         | ~64% core saturation | 1.71ms                           |
+
+
+
+### rk3566 
+
+Results for the rk3566 with 1 TOPS single core NPU operating at 900Mhz.
+
+
+| Number of Runtimes | Execution Time | Core Saturation      | Average Inference Time Per Image |
+|--------------------|----------------|----------------------|----------------------------------|
+| 1                  | 177.66s        | ~29% core saturation | 22.21ms                          |
+| 2                  | 87.25s         | ~43% core saturation | 10.91ms                          |
+| 3                  | 68.06s         | ~58% core saturation | 8.51ms                           |
+| 4                  | 60.60s         | ~70% core saturation | 7.58ms                           |
+| 5                  | 59.40s         | ~70% core saturation | 7.43ms                           |
+| 6                  | 53.81s         | ~76% core saturation | 6.73ms                           |
+
+

--- a/example/pool/README.md
+++ b/example/pool/README.md
@@ -29,7 +29,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 

--- a/example/ppocr/README.md
+++ b/example/ppocr/README.md
@@ -19,7 +19,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 

--- a/example/ppocr/README.md
+++ b/example/ppocr/README.md
@@ -29,39 +29,39 @@ git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 
 ### Usage
 
-Run the PPOCR Detection example.
+Run the PPOCR Detection example on rk3588 or replace with your Platform model.
 ```
 cd example/ppocr/detect
-go run detect.go
+go run detect.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 1
 Input tensors:
   index=0, name=x, n_dims=4, dims=[1, 480, 480, 3], n_elems=691200, size=691200, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-14, scale=0.018658
 Output tensors:
   index=0, name=sigmoid_0.tmp_0, n_dims=4, dims=[1, 1, 480, 480], n_elems=230400, size=230400, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
-Model first run speed: inference=27.746374ms, post processing=2.968795ms, total time=30.715169ms
-[0]: [(27, 459), (136, 459), (136, 478), (27, 478)] 0.991298
-[1]: [(27, 428), (371, 427), (371, 444), (27, 445)] 0.912538
-[2]: [(28, 398), (361, 397), (361, 413), (28, 414)] 0.953752
-[3]: [(368, 368), (476, 368), (476, 388), (368, 388)] 0.989887
-[4]: [(27, 365), (282, 365), (282, 384), (27, 384)] 0.975041
-[5]: [(26, 334), (342, 334), (342, 352), (26, 352)] 0.956719
-[6]: [(26, 303), (253, 303), (253, 320), (26, 320)] 0.974053
-[7]: [(25, 270), (179, 270), (179, 289), (25, 289)] 0.990559
-[8]: [(26, 240), (242, 240), (242, 259), (26, 259)] 0.986159
-[9]: [(413, 233), (429, 233), (429, 305), (413, 305)] 0.970001
-[10]: [(26, 209), (235, 209), (235, 227), (26, 227)] 0.995540
-[11]: [(26, 178), (300, 179), (300, 196), (26, 195)] 0.991055
-[12]: [(28, 143), (280, 144), (280, 164), (28, 163)] 0.974824
-[13]: [(27, 112), (333, 113), (333, 135), (27, 134)] 0.899956
-[14]: [(26, 81), (172, 81), (172, 103), (26, 103)] 0.994091
-[15]: [(28, 38), (302, 39), (302, 71), (28, 70)] 0.960498
-Saved image to ../data/ppocr-det-out.png
-Benchmark time=3.540086219s, count=100, average total time=35.400862ms
+Model first run speed: inference=49.443453ms, post processing=4.237269ms, total time=53.680722ms
+Saved image to ../../data/ppocr-det-out.png
+[0]: [(27, 459), (136, 459), (136, 478), (27, 478)] 0.978851
+[1]: [(29, 430), (370, 429), (370, 443), (29, 444)] 0.936015
+[2]: [(26, 396), (362, 396), (362, 414), (26, 414)] 0.949735
+[3]: [(369, 368), (476, 368), (476, 388), (369, 388)] 0.977374
+[4]: [(27, 366), (282, 365), (282, 384), (27, 385)] 0.908594
+[5]: [(25, 334), (343, 334), (343, 352), (25, 352)] 0.953618
+[6]: [(26, 303), (252, 303), (252, 320), (26, 320)] 0.977526
+[7]: [(25, 270), (179, 270), (179, 289), (25, 289)] 0.990133
+[8]: [(25, 240), (242, 240), (242, 259), (25, 259)] 0.988332
+[9]: [(413, 233), (429, 233), (429, 304), (413, 304)] 0.967471
+[10]: [(26, 209), (235, 209), (235, 227), (26, 227)] 0.998661
+[11]: [(26, 178), (301, 178), (301, 195), (26, 195)] 0.992206
+[12]: [(28, 143), (280, 144), (280, 163), (28, 162)] 0.957155
+[13]: [(27, 112), (332, 113), (332, 134), (27, 133)] 0.902135
+[14]: [(26, 81), (171, 81), (171, 103), (26, 103)] 0.995144
+[15]: [(28, 38), (302, 39), (302, 71), (28, 70)] 0.959944
+Benchmark time=3.270392909s, count=100, average total time=32.703929ms
 done
 ```
 
@@ -85,9 +85,24 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/ppocr/detect/detect.go
+  go run ./example/ppocr/detect/detect.go -p rk3588
 ```
 
+
+### Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 3.27s          | 32.70ms                          |
+| rk3576   | 2.95s          | 29.52ms                          |
+| rk3566   | 5.75s          | 57.51ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
 
 
 ### Background
@@ -101,23 +116,23 @@ This PPOCR Detect example is a Go conversion of the [C API example](https://gith
 
 ### Usage
 
-Run the PPOCR Recognition example.
+Run the PPOCR Recognition example on rk3588 or replace with your Platform model.
 ```
 cd example/ppocr/recognise
-go run recognise.go
+go run recognise.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 1
 Input tensors:
   index=0, name=x, n_dims=4, dims=[1, 48, 320, 3], n_elems=46080, size=92160, fmt=NHWC, type=FP16, qnt_type=AFFINE, zp=0, scale=1.000000
 Output tensors:
   index=0, name=softmax_11.tmp_0, n_dims=3, dims=[1, 40, 6625, 0], n_elems=265000, size=530000, fmt=UNDEFINED, type=FP16, qnt_type=AFFINE, zp=0, scale=1.000000
-Model first run speed: inference=26.486118ms, post processing=461.404µs, total time=26.947522ms
+Model first run speed: inference=31.240498ms, post processing=494.659µs, total time=31.735157ms
 Recognize result: JOINT, score=0.71
-Benchmark time=2.528564774s, count=100, average total time=25.285647ms
+Benchmark time=1.655360827s, count=100, average total time=16.553608ms
 done
 ```
 
@@ -147,7 +162,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/ppocr/recognise/recognise.go
+  go run ./example/ppocr/recognise/recognise.go -p rk3588
 ```
 
 
@@ -246,6 +261,23 @@ is a [discussion](https://github.com/PaddlePaddle/PaddleOCR/issues/11859) on how
 to improve the situation.  Hopefully the other languages get updates to v4 models
 in the future.
 
+
+### Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 1.65s          | 16.55ms                          |
+| rk3576   | 2.34s          | 23.40ms                          |
+| rk3566   | 5.93s          | 59.35ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.
+
+
+
 ### Background
 
 This PPOCR Recognise example is a Go conversion of the [C API example](https://github.com/airockchip/rknn_model_zoo/blob/main/examples/PPOCR/PPOCR-Rec/cpp/main.cc).
@@ -260,62 +292,62 @@ This PPOCR Recognise example is a Go conversion of the [C API example](https://g
 
 ### Usage
 
-Run the PPOCR System example.
+Run the PPOCR System example on rk3588 or replace with your Platform model.
 ```
 cd example/ppocr/system
-go run system.go
+go run system.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 1
 Input tensors:
   index=0, name=x, n_dims=4, dims=[1, 48, 320, 3], n_elems=46080, size=92160, fmt=NHWC, type=FP16, qnt_type=AFFINE, zp=0, scale=1.000000
 Output tensors:
   index=0, name=softmax_11.tmp_0, n_dims=3, dims=[1, 40, 6625, 0], n_elems=265000, size=530000, fmt=UNDEFINED, type=FP16, qnt_type=AFFINE, zp=0, scale=1.000000
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 1
 Input tensors:
   index=0, name=x, n_dims=4, dims=[1, 480, 480, 3], n_elems=691200, size=691200, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-14, scale=0.018658
 Output tensors:
   index=0, name=sigmoid_0.tmp_0, n_dims=4, dims=[1, 1, 480, 480], n_elems=230400, size=230400, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
-[0]: [(28, 38), (302, 39), (302, 71), (28, 70)] 0.960498
+[0]: [(28, 38), (302, 39), (302, 71), (28, 70)] 0.959944
 Recognize result: 纯臻营养护发素, score=0.71
-[1]: [(26, 81), (172, 81), (172, 103), (26, 103)] 0.994091
+[1]: [(26, 81), (171, 81), (171, 103), (26, 103)] 0.995144
+[2]: [(27, 112), (332, 113), (332, 134), (27, 133)] 0.902135
 Recognize result: 产品信息/参数, score=0.71
-[2]: [(27, 112), (333, 113), (333, 135), (27, 134)] 0.899956
 Recognize result: （45元/每公斤，100公斤起订）, score=0.69
-[3]: [(28, 143), (280, 144), (280, 164), (28, 163)] 0.974824
-Recognize result: 每瓶22元，1000瓶起订）, score=0.70
-[4]: [(26, 178), (300, 179), (300, 196), (26, 195)] 0.991055
-Recognize result: （品牌】：代加工方式/OEMODM, score=0.67
-[5]: [(26, 209), (235, 209), (235, 227), (26, 227)] 0.995540
-Recognize result: 【品名】：纯臻营养护发素, score=0.70
-[6]: [(26, 240), (242, 240), (242, 259), (26, 259)] 0.986159
+[3]: [(28, 143), (280, 144), (280, 163), (28, 162)] 0.957155
+Recognize result: 每瓶22元，1000瓶起订）, score=0.68
+[4]: [(26, 178), (301, 178), (301, 195), (26, 195)] 0.992206
+Recognize result: 【品牌】：代加工方式/OEMODM, score=0.64
+[5]: [(26, 209), (235, 209), (235, 227), (26, 227)] 0.998661
+Recognize result: 【品名】：纯臻营养护发素, score=0.71
+[6]: [(25, 240), (242, 240), (242, 259), (25, 259)] 0.988332
+[7]: [(413, 233), (429, 233), (429, 304), (413, 304)] 0.967471
 Recognize result: 【产品编号】：YM-X-3011, score=0.71
-[7]: [(413, 233), (429, 233), (429, 305), (413, 305)] 0.970001
-Recognize result: ODMOEM, score=0.71
-[8]: [(25, 270), (179, 270), (179, 289), (25, 289)] 0.990559
+[8]: [(25, 270), (179, 270), (179, 289), (25, 289)] 0.990133
+Recognize result: ODMOEM, score=0.70
+[9]: [(26, 303), (252, 303), (252, 320), (26, 320)] 0.977526
 Recognize result: 【净含量】：220ml, score=0.71
-[9]: [(26, 303), (253, 303), (253, 320), (26, 320)] 0.974053
 Recognize result: 【适用人群】：适合所有肤质, score=0.71
-[10]: [(26, 334), (342, 334), (342, 352), (26, 352)] 0.956719
-Recognize result: （主要成分》:皖蜡硬脂醇、燕麦-葡聚, score=0.59
-[11]: [(27, 365), (282, 365), (282, 384), (27, 384)] 0.975041
-Recognize result: 糖、椰油酰胺丙基甜菜碱、泛酸, score=0.68
-[12]: [(368, 368), (476, 368), (476, 388), (368, 388)] 0.989887
-Recognize result: （成品包材）, score=0.71
-[13]: [(28, 398), (361, 397), (361, 413), (28, 414)] 0.953752
-Recognize result: 干型功能:可降较以发确员，从而大有, score=0.41
-[14]: [(27, 428), (371, 427), (371, 444), (27, 445)] 0.912538
-Recognize result: 即时语久改基发光器的双果，给干强的头, score=0.47
-[15]: [(27, 459), (136, 459), (136, 478), (27, 478)] 0.991298
+[10]: [(25, 334), (343, 334), (343, 352), (25, 352)] 0.953618
+[11]: [(27, 366), (282, 365), (282, 384), (27, 385)] 0.908594
+Recognize result: 【主要成分】:皖蜡硬脂醇、燕麦β-葡聚, score=0.62
+[12]: [(369, 368), (476, 368), (476, 388), (369, 388)] 0.977374
+Recognize result: 糖、椰油酰胺丙基甜菜碱、泛酯, score=0.67
+Recognize result: （成品包材）, score=0.70
+[13]: [(26, 396), (362, 396), (362, 414), (26, 414)] 0.949735
+[14]: [(29, 430), (370, 429), (370, 443), (29, 444)] 0.936015
+Recognize result: 【主要功能】：可紧致头发磷层，从而达到, score=0.66
+[15]: [(27, 459), (136, 459), (136, 478), (27, 478)] 0.978851
+Recognize result: RA V型S发研至NW果 治 N2, score=0.27
 Recognize result: 发足够的滋养, score=0.71
 Run speed:
-  Detect processing=32.056505ms
-  Recognise processing=362.731907ms
-  Total time=394.788412ms
+  Detect processing=58.256248ms
+  Recognise processing=264.197813ms
+  Total time=322.454061ms
 done
 ```
 
@@ -338,9 +370,8 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/ppocr/system/system.go
+  go run ./example/ppocr/system/system.go -p rk3588
 ```
-
 
 
 ### Background

--- a/example/ppocr/detect/detect.go
+++ b/example/ppocr/detect/detect.go
@@ -12,6 +12,7 @@ import (
 	"image/color"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -20,19 +21,26 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../../data/ppocrv4_det-rk3588.rknn", "RKNN compiled model file")
+	modelFile := flag.String("m", "../../data/models/rk3588/ppocrv4_det-rk3588.rknn", "RKNN compiled model file")
 	imgFile := flag.String("i", "../../data/ppocr-det-test.png", "Image file to run inference on")
 	saveFile := flag.String("o", "../../data/ppocr-det-out.png", "The output PNG file with object detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)

--- a/example/ppocr/recognise/recognise.go
+++ b/example/ppocr/recognise/recognise.go
@@ -12,6 +12,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -20,19 +21,26 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../../data/ppocrv4_rec-rk3588.rknn", "RKNN compiled model file")
+	modelFile := flag.String("m", "../../data/models/rk3588/ppocrv4_rec-rk3588.rknn", "RKNN compiled model file")
 	imgFile := flag.String("i", "../../data/ppocr-rec-test.png", "Image file to run inference on")
 	keysFile := flag.String("k", "../../data/ppocr_keys_v1.txt", "Text file containing OCR character keys")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)

--- a/example/retinaface/README.md
+++ b/example/retinaface/README.md
@@ -13,7 +13,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the RetinaFace example.

--- a/example/retinaface/README.md
+++ b/example/retinaface/README.md
@@ -16,15 +16,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the RetinaFace example.
+Run the RetinaFace example on rk3588 or replace with your Platform model.
 ```
 cd example/retinaface
-go run retinaface.go
+go run retinaface.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 3
 Input tensors:
   index=0, name=input0, n_dims=4, dims=[1, 320, 320, 3], n_elems=307200, size=307200, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-14, scale=1.074510
@@ -32,6 +32,7 @@ Output tensors:
   index=0, name=output0, n_dims=3, dims=[1, 4200, 4, 0], n_elems=16800, size=16800, fmt=UNDEFINED, type=INT8, qnt_type=AFFINE, zp=0, scale=0.044699
   index=1, name=572, n_dims=3, dims=[1, 4200, 2, 0], n_elems=8400, size=16800, fmt=UNDEFINED, type=FP16, qnt_type=AFFINE, zp=0, scale=1.000000
   index=2, name=571, n_dims=3, dims=[1, 4200, 10, 0], n_elems=42000, size=42000, fmt=UNDEFINED, type=INT8, qnt_type=AFFINE, zp=-22, scale=0.086195
+Model first run speed: inference=9.732158ms, post processing=163.914µs, rendering=1.654012ms, total time=11.550084ms
 face @ (312 531 453 714) 0.998047
 face @ (306 289 436 454) 0.997559
 face @ (53 286 184 460) 0.996582
@@ -41,9 +42,8 @@ face @ (61 34 192 209) 0.994629
 face @ (523 274 674 474) 0.994141
 face @ (553 28 695 224) 0.991211
 face @ (292 36 421 217) 0.991211
-Model first run speed: inference=8.527569ms, post processing=217.287µs, rendering=2.15333ms, total time=10.898186ms
 Saved object detection result to ../data/face-out.jpg
-Benchmark time=179.448201ms, count=20, average total time=8.97241ms
+Benchmark time=573.784348ms, count=100, average total time=5.737843ms
 done
 ```
 
@@ -57,13 +57,15 @@ See the help for command line parameters.
 ```
 $ go run retinaface.go --help
 
-Usage of /tmp/go-build3929104604/b001/exe/retinaface:
+Usage of /tmp/go-build3703609935/b001/exe/retinaface:
   -i string
         Image file to run inference on (default "../data/face.jpg")
   -m string
-        RKNN compiled Retina Face model file (default "../data/retinaface-320-320-rk3588.rknn")
+        RKNN compiled Retina Face model file (default "../data/models/rk3588/retinaface-320-rk3588.rknn")
   -o string
         The output JPG file with face detection markers (default "../data/face-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
 ```
 
 
@@ -82,8 +84,24 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/retinaface/retinaface.go
+  go run ./example/retinaface/retinaface.go -p rk3588
 ```
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 0.57s          | 5.73ms                           |
+| rk3576   | 0.52s          | 5.27ms                           |
+| rk3566   | 1.12s          | 11.21ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available. Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
 
 
 

--- a/example/stream/README.md
+++ b/example/stream/README.md
@@ -47,16 +47,15 @@ git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Start the Stream server on port `8080` and run the example using a pool 
-of `3` YOLO models and limiting object detection to `person`.
+of `3` YOLO models and limiting object detection to `person`
+on rk3588 or replace with your Platform model.
 ```
 cd example/stream/
-go run bytetrack.go -a :8080 -s 3 -x person
+go run bytetrack.go -a :8080 -s 3 -x person -p rk3588
 ```
 
 This will result in output of:
 ```
-Model Input Tensor Dimensions 640x640
-Scale factor: Width=2.000, Height=1.125
 Limiting object detection class to: person
 Open browser and view video at http://:8080/stream
 ```
@@ -86,7 +85,7 @@ docker run --rm -it \
   -w /go/src/app \
   -p 8080:8080 \
   swdee/go-rknnlite:latest \
-  go run ./example/stream/bytetrack.go -a :8080 -s 3 -x person
+  go run ./example/stream/bytetrack.go -a :8080 -s 3 -x person -p rk3588
 ```
 
 
@@ -100,6 +99,7 @@ go run bytetrack.go --help
 
 This outputs options of:
 ```
+Usage of /tmp/go-build3419105702/b001/exe/bytetrack:
   -a string
         HTTP Address to run server on, format address:port (default "localhost:8080")
   -c value
@@ -109,7 +109,9 @@ This outputs options of:
   -l string
         Text file containing model labels (default "../data/coco_80_labels_list.txt")
   -m string
-        RKNN compiled YOLO model file (default "../data/yolov5s-640-640-rk3588.rknn")
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov5s-rk3588.rknn")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
   -r string
         The rendering format used for instance segmentation [outline|mask] (default "outline")
   -s int
@@ -125,16 +127,16 @@ This outputs options of:
 The default mode is to use the YOLOv5 model, however you can change to other models with.
 ```
 # YOLOv8
-go run bytetrack.go -a :8080 -s 3 -x person -m ../data/yolov8s-640-640-rk3588.rknn -t v8
+go run bytetrack.go -a :8080 -s 3 -x person -p rk3588 -m ../data/yolov8s-rk3588.rknn -t v8
 
 # YOLOv10
-go run bytetrack.go -a :8080 -s 3 -x person -m ../data/yolov10s-640-640-rk3588.rknn -t v10
+go run bytetrack.go -a :8080 -s 3 -x person -p rk3588 -m ../data/yolov10s-rk3588.rknn -t v10
 
 # YOLOv11
-go run bytetrack.go -a :8080 -s 3 -x person -m ../data/yolov11s-640-640-rk3588.rknn -t v11
+go run bytetrack.go -a :8080 -s 3 -x person -p rk3588 -m ../data/yolov11s-rk3588.rknn -t v11
 
 # YOLOX
-go run bytetrack.go -a :8080 -s 3 -x person -m ../data/yoloxs-640-640-rk3588.rknn -t x
+go run bytetrack.go -a :8080 -s 3 -x person -p rk3588 -m ../data/yoloxs-rk3588.rknn -t x
 ```
 
 The YOLO models used are the original ones from the RKNN Model Zoo and are not tuned 
@@ -182,7 +184,7 @@ resolution and frame rate of `-c 1280x720@30` on the command line to represent
 `/dev/video1` and a resolution of `1280x720` running at `30`FPS.
 
 ```
-go run bytetrack.go -a :8080 -s 6 -v 1 -c 640x480@30 -codec MJPG -m ../data/yolov8n-pose-640-640-rk3588.rknn -t v8pose
+go run bytetrack.go -a :8080 -s 6 -v 1 -c 640x480@30 -codec MJPG -m ../data/yolov8n-pose-rk3588.rknn -t v8pose -p rk3588
 ```
 
 
@@ -269,7 +271,7 @@ The YOLOv8-pose processor has been added to this Stream example, use the followi
 video to view example.
 
 ```
-go run bytetrack.go -a :8080 -s 3 -v ../data/dance.mp4 -t v8pose -m ../data/yolov8n-pose-640-640-rk3588.rknn
+go run bytetrack.go -a :8080 -s 3 -v ../data/dance.mp4 -t v8pose -m ../data/yolov8n-pose-rk3588.rknn -p rk3588
 ```
 
 Tracking trails have been turned off as the trails distract from the skeleton.
@@ -281,7 +283,7 @@ Using the YOLOv8-obb processor and example has been added for object detection
 using oriented bounding boxes.
 
 ```
-go run bytetrack.go -a :8080 -s 3 -v ../data/aerial.mp4 -t v8obb -m ../data/yolov8n-obb-640-640-rk3588.rknn -l ../data/yolov8_obb_labels_list.txt
+go run bytetrack.go -a :8080 -s 3 -v ../data/aerial.mp4 -t v8obb -m ../data/yolov8n-obb-rk3588.rknn -l ../data/yolov8_obb_labels_list.txt -p rk3588
 ```
 
 

--- a/example/stream/README.md
+++ b/example/stream/README.md
@@ -43,7 +43,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Start the Stream server on port `8080` and run the example using a pool 

--- a/example/yolov10/README.md
+++ b/example/yolov10/README.md
@@ -8,7 +8,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOv10 example.

--- a/example/yolov10/README.md
+++ b/example/yolov10/README.md
@@ -11,32 +11,33 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOv10 example.
+Run the YOLOv10 example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov10
-go run yolov10.go
+go run yolov10.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 6
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
 Output tensors:
-  index=0, name=502, n_dims=4, dims=[1, 64, 80, 80], n_elems=409600, size=409600, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-62, scale=0.086849
-  index=1, name=516, n_dims=4, dims=[1, 80, 80, 80], n_elems=512000, size=512000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.002931
-  index=2, name=523, n_dims=4, dims=[1, 64, 40, 40], n_elems=102400, size=102400, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-55, scale=0.072764
-  index=3, name=537, n_dims=4, dims=[1, 80, 40, 40], n_elems=128000, size=128000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003646
-  index=4, name=544, n_dims=4, dims=[1, 64, 20, 20], n_elems=25600, size=25600, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-68, scale=0.058066
-  index=5, name=558, n_dims=4, dims=[1, 80, 20, 20], n_elems=32000, size=32000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003894
-bus @ (92 136 555 436) 0.958003
-person @ (110 235 226 536) 0.907376
-person @ (212 240 285 509) 0.887905
-person @ (476 233 559 521) 0.829490
-Model first run speed: inference=58.666351ms, post processing=2.771067ms, rendering=1.236349ms, total time=62.673767ms
+  index=0, name=485, n_dims=4, dims=[1, 64, 80, 80], n_elems=409600, size=409600, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-62, scale=0.086849
+  index=1, name=499, n_dims=4, dims=[1, 80, 80, 80], n_elems=512000, size=512000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.002931
+  index=2, name=506, n_dims=4, dims=[1, 64, 40, 40], n_elems=102400, size=102400, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-55, scale=0.072764
+  index=3, name=520, n_dims=4, dims=[1, 80, 40, 40], n_elems=128000, size=128000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003646
+  index=4, name=527, n_dims=4, dims=[1, 64, 20, 20], n_elems=25600, size=25600, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-68, scale=0.058066
+  index=5, name=541, n_dims=4, dims=[1, 80, 20, 20], n_elems=32000, size=32000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003894
+bus @ (92 136 555 436) 0.954108
+person @ (110 234 226 536) 0.911271
+person @ (212 240 285 509) 0.872328
+person @ (477 233 559 521) 0.825596
+person @ (80 330 123 514) 0.488516
+Model first run speed: inference=47.048717ms, post processing=1.271934ms, rendering=713.403µs, total time=49.034054ms
 Saved object detection result to ../data/bus-yolov10-out.jpg
-Benchmark time=4.144871338s, count=100, average total time=41.448713ms
+Benchmark time=4.091851863s, count=100, average total time=40.918518ms
 done
 ```
 
@@ -47,12 +48,30 @@ The saved JPG image with object detection markers.
 
 To use your own RKNN compiled model and images.
 ```
-go run yolov10.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file>
+go run yolov10.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file> -p <platform>
 ```
 
 The labels file should be a text file containing the labels the Model was trained on.
 It should have one label per line.
 
+
+
+See the help for command line parameters.
+```
+$ go run yolov10.go --help
+
+Usage of /tmp/go-build859033258/b001/exe/yolov10:
+  -i string
+        Image file to run object detection on (default "../data/bus.jpg")
+  -l string
+        Text file containing model labels (default "../data/coco_80_labels_list.txt")
+  -m string
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov10s-rk3588.rknn")
+  -o string
+        The output JPG file with object detection markers (default "../data/bus-yolov10-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
+```
 
 
 ### Docker
@@ -70,10 +89,8 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov10/yolov10.go
+  go run ./example/yolov10/yolov10.go -p rk3588
 ```
-
-
 
 
 ## Proprietary Models
@@ -86,6 +103,24 @@ with your own `YOLOv10Params`.
 
 In the file `postprocess/yolov10.go` see function `YOLOv10COCOParams` for how to
 configure your own custom parameters.
+
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 4.09s          | 40.91ms                          |
+| rk3576   | 3.52s          | 35.28ms                          |
+| rk3566   | 11.79s         | 117.92ms                         |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
+
 
 
 ## Background

--- a/example/yolov10/yolov10.go
+++ b/example/yolov10/yolov10.go
@@ -13,6 +13,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -21,21 +22,28 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov10s-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov10s-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/bus.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/coco_80_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/bus-yolov10-out.jpg", "The output JPG file with object detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)

--- a/example/yolov11/README.md
+++ b/example/yolov11/README.md
@@ -11,15 +11,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOv11 example.
+Run the YOLOv11 example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov11
-go run yolov11.go
+go run yolov11.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 9
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
@@ -33,14 +33,14 @@ Output tensors:
   index=6, name=512, n_dims=4, dims=[1, 64, 20, 20], n_elems=25600, size=25600, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-44, scale=0.078218
   index=7, name=onnx::ReduceSum_526, n_dims=4, dims=[1, 80, 20, 20], n_elems=32000, size=32000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003861
   index=8, name=530, n_dims=4, dims=[1, 1, 20, 20], n_elems=400, size=400, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003878
-bus @ (94 134 551 437) 0.945933
-person @ (475 231 559 522) 0.895741
-person @ (108 233 227 535) 0.891880
-person @ (211 240 284 508) 0.888019
-person @ (79 325 126 518) 0.606169
-Model first run speed: inference=62.703784ms, post processing=1.303424ms, rendering=1.429421ms, total time=65.436629ms
+bus @ (93 134 552 437) 0.942072
+person @ (476 231 559 522) 0.899602
+person @ (108 237 225 537) 0.891880
+person @ (211 240 283 508) 0.884158
+person @ (79 326 126 518) 0.613891
+Model first run speed: inference=48.848268ms, post processing=597.322µs, rendering=702.611µs, total time=50.148201ms
 Saved object detection result to ../data/bus-yolov11-out.jpg
-Benchmark time=4.206316731s, count=100, average total time=42.063167ms
+Benchmark time=3.980790684s, count=100, average total time=39.807906ms
 done
 ```
 
@@ -51,13 +51,29 @@ The saved JPG image with object detection markers.
 
 To use your own RKNN compiled model and images.
 ```
-go run yolov11.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file>
+go run yolov11.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file> -p <platform>
 ```
 
 The labels file should be a text file containing the labels the Model was trained on.
 It should have one label per line.
 
 
+See the help for command line parameters.
+```
+$ go run yolov11.go --help
+
+Usage of /tmp/go-build4280368118/b001/exe/yolov11:
+  -i string
+        Image file to run object detection on (default "../data/bus.jpg")
+  -l string
+        Text file containing model labels (default "../data/coco_80_labels_list.txt")
+  -m string
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov11s-rk3588.rknn")
+  -o string
+        The output JPG file with object detection markers (default "../data/bus-yolov11-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
+```
 
 
 ### Docker
@@ -75,7 +91,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov11/yolov11.go
+  go run ./example/yolov11/yolov11.go -p rk3588
 ```
 
 
@@ -90,6 +106,25 @@ with your own `YOLOv11Params`.
 
 In the file `postprocess/yolov11.go` see function `YOLOv11COCOParams` for how to
 configure your own custom parameters.
+
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 3.98s          | 39.80ms                          |
+| rk3576   | 4.11s          | 41.19ms                          |
+| rk3566   | 11.57s         | 115.73ms                         |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
+
+
 
 
 ## Background

--- a/example/yolov11/README.md
+++ b/example/yolov11/README.md
@@ -8,7 +8,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOv11 example.

--- a/example/yolov11/yolov11.go
+++ b/example/yolov11/yolov11.go
@@ -13,6 +13,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -21,21 +22,28 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov11s-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov11s-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/bus.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/coco_80_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/bus-yolov11-out.jpg", "The output JPG file with object detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)

--- a/example/yolov5-seg/README.md
+++ b/example/yolov5-seg/README.md
@@ -11,7 +11,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOv5-seg example.

--- a/example/yolov5-seg/README.md
+++ b/example/yolov5-seg/README.md
@@ -14,15 +14,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOv5-seg example.
+Run the YOLOv5-seg example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov5-seg
-go run yolov5-seg.go
+go run yolov5-seg.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 7
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
@@ -39,9 +39,9 @@ cat @ (714 101 900 336) 0.706588
 dog @ (312 93 526 304) 0.693387
 cat @ (28 113 171 292) 0.641764
 cat @ (530 141 712 299) 0.616804
-Model first run speed: inference=53.284047ms, post processing=46.035115ms, rendering=7.266431ms, total time=106.585593ms
+Model first run speed: inference=45.977719ms, post processing=46.101967ms, rendering=1.395305ms, total time=93.474991ms
 Saved object detection result to ../data/catdog-yolov5-seg-out.jpg
-Benchmark time=1.998158455s, count=20, average total time=99.907922ms
+Benchmark time=7.346591785s, count=100, average total time=73.465917ms
 done
 ```
 
@@ -54,15 +54,17 @@ See the help for command line parameters.
 ```
 $ go run yolov5-seg.go --help
 
-Usage of /tmp/go-build401282281/b001/exe/yolov5-seg:
+Usage of /tmp/go-build2169893350/b001/exe/yolov5-seg:
   -i string
         Image file to run object detection on (default "../data/catdog.jpg")
   -l string
         Text file containing model labels (default "../data/coco_80_labels_list.txt")
   -m string
-        RKNN compiled YOLO model file (default "../data/yolov5s-seg-640-640-rk3588.rknn")
+        RKNN compiled YOLO model file (default "../data/yolov5s-seg-rk3588.rknn")
   -o string
         The output JPG file with object detection markers (default "../data/catdog-yolov5-seg-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
   -r string
         The rendering format used for instance segmentation [outline|mask|dump] (default "outline")
 ```
@@ -82,7 +84,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov5-seg/yolov5-seg.go
+  go run ./example/yolov5-seg/yolov5-seg.go -p rk3588
 ```
 
 
@@ -99,7 +101,7 @@ the object and provides a single transparent overlay to indicate the segment mas
 
 This can be output with the following flag.
 ```
-go run yolov5-seg.go -r mask
+go run yolov5-seg.go -p rk3588 -r mask
 ```
 
 ![catdog-mask.jpg](catdog-mask.jpg)
@@ -107,7 +109,7 @@ go run yolov5-seg.go -r mask
 For visualisation and debugging purposes the segmentation mask can also be dumped
 to an image.
 ```
-go run yolov5-seg.go -r dump
+go run yolov5-seg.go -p rk3588 -r dump
 ```
 
 ![catdog-dump.jpg](catdog-dump.jpg)
@@ -132,6 +134,23 @@ yParams.PrototypeWeight = 320
 // create YOLO Processor instance	
 yoloProcesser := postprocess.NewYOLOv5Seg(yParams)
 ```
+
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 7.34s          | 73.46ms                          |
+| rk3576   | 8.91s          | 89.14ms                          |
+| rk3566   | 32.64s         | 326.44ms                         |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
 
 
 

--- a/example/yolov5-seg/yolov5-seg.go
+++ b/example/yolov5-seg/yolov5-seg.go
@@ -10,6 +10,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -18,22 +19,29 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov5s-seg-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov5s-seg-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/catdog.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/coco_80_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/catdog-yolov5-seg-out.jpg", "The output JPG file with object detection markers")
 	renderFormat := flag.String("r", "outline", "The rendering format used for instance segmentation [outline|mask|dump]")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)
@@ -172,7 +180,7 @@ func runBenchmark(rt *rknnlite.Runtime, yoloProcesser *postprocess.YOLOv5Seg,
 	mats []gocv.Mat, classNames []string, resizer *preprocess.Resizer,
 	renderFormat string, srcImg gocv.Mat) {
 
-	count := 20
+	count := 100
 	start := time.Now()
 
 	for i := 0; i < count; i++ {

--- a/example/yolov5/README.md
+++ b/example/yolov5/README.md
@@ -8,7 +8,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the Yolov5 example.

--- a/example/yolov5/README.md
+++ b/example/yolov5/README.md
@@ -11,30 +11,30 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the Yolov5 example.
+Run the Yolov5 example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov5
-go run yolov5.go
+go run yolov5.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 3
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
 Output tensors:
   index=0, name=output0, n_dims=4, dims=[1, 255, 80, 80], n_elems=1632000, size=1632000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
-  index=1, name=286, n_dims=4, dims=[1, 255, 40, 40], n_elems=408000, size=408000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
-  index=2, name=288, n_dims=4, dims=[1, 255, 20, 20], n_elems=102000, size=102000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
-person @ (209 243 286 510) 0.879723
-person @ (479 238 560 526) 0.870588
-person @ (109 238 231 534) 0.839831
-bus @ (91 129 555 464) 0.692042
-person @ (79 353 121 517) 0.300961
-Model first run speed: inference=32.144783ms, post processing=422.908µs, rendering=1.405512ms, total time=33.973203ms
+  index=1, name=343, n_dims=4, dims=[1, 255, 40, 40], n_elems=408000, size=408000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
+  index=2, name=345, n_dims=4, dims=[1, 255, 20, 20], n_elems=102000, size=102000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
+person @ (210 242 282 519) 0.831880
+person @ (474 229 561 522) 0.805398
+person @ (114 239 207 540) 0.788235
+bus @ (90 135 553 459) 0.771211
+person @ (78 331 122 519) 0.413103
+Model first run speed: inference=34.342902ms, post processing=181.705µs, rendering=1.119107ms, total time=35.643714ms
 Saved object detection result to ../data/bus-yolov5-out.jpg
-Benchmark time=2.104920231s, count=100, average total time=21.049202ms
+Benchmark time=2.726533944s, count=100, average total time=27.265339ms
 done
 ```
 
@@ -46,11 +46,30 @@ The saved JPG image with object detection markers.
 
 To use your own RKNN compiled model and images.
 ```
-go run yolov5.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file>
+go run yolov5.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file> -p <platform>
 ```
 
 The labels file should be a text file containing the labels the Model was trained on.
 It should have one label per line.
+
+
+See the help for command line parameters.
+```
+$ go run yolov5.go --help
+
+Usage of /tmp/go-build3921202332/b001/exe/yolov5:
+  -i string
+        Image file to run object detection on (default "../data/bus.jpg")
+  -l string
+        Text file containing model labels (default "../data/coco_80_labels_list.txt")
+  -m string
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov5s-rk3588.rknn")
+  -o string
+        The output JPG file with object detection markers (default "../data/bus-yolov5-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
+```
+
 
 
 ### Docker
@@ -68,7 +87,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov5/yolov5.go
+  go run ./example/yolov5/yolov5.go -p rk3588
 ```
 
 
@@ -83,6 +102,25 @@ with your own `YOLOv5Params`.
 
 In the file `postprocess/yolov5.go` see function `YOLOv5COCOParams` for how to
 configure your own custom parameters. 
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 3.00s          | 30.07ms                          |
+| rk3576   | 2.48s          | 24.85ms                          |
+| rk3566   | 6.68s          | 66.80ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory which
+explains the faster result. 
+
+
 
 
 ## Background

--- a/example/yolov5/yolov5.go
+++ b/example/yolov5/yolov5.go
@@ -13,6 +13,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -21,21 +22,28 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov5s-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov5s-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/bus.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/coco_80_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/bus-yolov5-out.jpg", "The output JPG file with object detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)

--- a/example/yolov8-obb/README.md
+++ b/example/yolov8-obb/README.md
@@ -17,7 +17,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOv8-obb example.

--- a/example/yolov8-obb/README.md
+++ b/example/yolov8-obb/README.md
@@ -20,15 +20,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOv8-obb example.
+Run the YOLOv8-obb example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov8-obb
-go run yolov8-obb.go
+go run yolov8-obb.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 4
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
@@ -63,9 +63,9 @@ small vehicle @ (774 396 66 32 angle=0.544957) 0.603226
 large vehicle @ (793 248 72 30 angle=0.573063) 0.599939
 small vehicle @ (725 146 71 34 angle=0.563694) 0.552175
 small vehicle @ (943 512 68 29 angle=0.516851) 0.500000
-Model first run speed: inference=29.918049ms, post processing=7.956524ms, rendering=3.191652ms, total time=41.066225ms
+Model first run speed: inference=23.698907ms, post processing=3.55243ms, rendering=1.746757ms, total time=28.998094ms
 Saved object detection result to ../data/intersection-out.jpg
-Benchmark time=582.914292ms, count=20, average total time=29.145714ms
+Benchmark time=3.269129715s, count=100, average total time=32.691297ms
 done
 ```
 
@@ -81,15 +81,17 @@ See the help for command line parameters.
 ```
 $ go run yolov8-obb.go --help
 
-Usage of /tmp/go-build3751821681/b001/exe/yolov8-obb:
+Usage of /tmp/go-build1092312274/b001/exe/yolov8-obb:
   -i string
         Image file to run object detection on (default "../data/intersection.jpg")
   -l string
         Text file containing model labels (default "../data/yolov8_obb_labels_list.txt")
   -m string
-        RKNN compiled YOLO model file (default "../data/yolov8n-obb-640-640-rk3588.rknn")
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov8n-obb-rk3588.rknn")
   -o string
         The output JPG file with pose detection markers (default "../data/intersection-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
 ```
 
 
@@ -108,8 +110,24 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov8-obb/yolov8-obb.go
+  go run ./example/yolov8-obb/yolov8-obb.go -p rk3588
 ```
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 3.26s          | 32.69ms                          |
+| rk3576   | 2.67s          | 26.78ms                          |
+| rk3566   | 5.95s          | 59.59ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
 
 
 

--- a/example/yolov8-obb/yolov8-obb.go
+++ b/example/yolov8-obb/yolov8-obb.go
@@ -14,6 +14,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -23,21 +24,28 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov8n-obb-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov8n-obb-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/intersection.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/yolov8_obb_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/intersection-out.jpg", "The output JPG file with pose detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)
@@ -149,7 +157,7 @@ func runBenchmark(rt *rknnlite.Runtime, yoloProcesser *postprocess.YOLOv8obb,
 	mats []gocv.Mat, classNames []string, resizer *preprocess.Resizer,
 	srcImg gocv.Mat) {
 
-	count := 20
+	count := 100
 	start := time.Now()
 
 	for i := 0; i < count; i++ {

--- a/example/yolov8-pose/README.md
+++ b/example/yolov8-pose/README.md
@@ -11,15 +11,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOv8-pose example.
+Run the YOLOv8-pose example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov8-pose
-go run yolov8-pose.go
+go run yolov8-pose.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 4
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
@@ -35,9 +35,9 @@ person @ (251 143 363 520) 0.872132
 person @ (678 112 779 526) 0.872132
 person @ (161 109 266 521) 0.872132
 person @ (572 103 686 528) 0.853203
-Model first run speed: inference=54.180286ms, post processing=1.000141ms, rendering=3.057007ms, total time=58.237434ms
+Model first run speed: inference=37.624844ms, post processing=465.199µs, rendering=1.815006ms, total time=39.905049ms
 Saved object detection result to ../data/people-yolov8-pose-out.jpg
-Benchmark time=951.037868ms, count=20, average total time=47.551893ms
+Benchmark time=2.860705252s, count=100, average total time=28.607052ms
 done
 ```
 
@@ -51,15 +51,17 @@ See the help for command line parameters.
 ```
 $ go run yolov8-pose.go --help
 
-Usage of /tmp/go-build1390906730/b001/exe/yolov8-pose:
+Usage of /tmp/go-build2381700544/b001/exe/yolov8-pose:
   -i string
         Image file to run object detection on (default "../data/people-poses.jpg")
   -l string
         Text file containing model labels (default "../data/yolov8_pose_labels_list.txt")
   -m string
-        RKNN compiled YOLO model file (default "../data/yolov8n-pose-640-640-rk3588.rknn")
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov8n-pose-rk3588.rknn")
   -o string
-        The output JPG file with pose detection markers (default "../data/people-yolov8-pose-out.jpg")       
+        The output JPG file with pose detection markers (default "../data/people-yolov8-pose-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
 ```
 
 
@@ -79,8 +81,24 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov8-pose/yolov8-pose.go
+  go run ./example/yolov8-pose/yolov8-pose.go -p rk3588
 ```
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 2.86s          | 28.60ms                          |
+| rk3576   | 3.64s          | 36.49ms                          |
+| rk3566   | 5.48s          | 54.84ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
+
 
 
 

--- a/example/yolov8-pose/README.md
+++ b/example/yolov8-pose/README.md
@@ -8,7 +8,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOv8-pose example.

--- a/example/yolov8-pose/yolov8-pose.go
+++ b/example/yolov8-pose/yolov8-pose.go
@@ -13,6 +13,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -21,21 +22,28 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov8n-pose-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov8n-pose-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/people-poses.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/yolov8_pose_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/people-yolov8-pose-out.jpg", "The output JPG file with pose detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)
@@ -150,7 +158,7 @@ func runBenchmark(rt *rknnlite.Runtime, yoloProcesser *postprocess.YOLOv8Pose,
 	mats []gocv.Mat, classNames []string, resizer *preprocess.Resizer,
 	srcImg gocv.Mat) {
 
-	count := 20
+	count := 100
 	start := time.Now()
 
 	for i := 0; i < count; i++ {

--- a/example/yolov8-seg/README.md
+++ b/example/yolov8-seg/README.md
@@ -14,15 +14,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOv8-seg example.
+Run the YOLOv8-seg example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov8-seg
-go run yolov8-seg.go
+go run yolov8-seg.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 13
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
@@ -40,14 +40,14 @@ Output tensors:
   index=10, name=426, n_dims=4, dims=[1, 1, 20, 20], n_elems=400, size=400, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
   index=11, name=368, n_dims=4, dims=[1, 32, 20, 20], n_elems=12800, size=12800, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=43, scale=0.019919
   index=12, name=347, n_dims=4, dims=[1, 32, 160, 160], n_elems=819200, size=819200, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-119, scale=0.032336
+Model first run speed: inference=53.334871ms, post processing=47.551235ms, rendering=1.356806ms, total time=102.242912ms
 cat @ (712 98 903 332) 0.918907
 cat @ (24 117 200 291) 0.860259
 dog @ (173 89 359 296) 0.857901
 dog @ (311 98 528 312) 0.831211
 cat @ (523 142 719 299) 0.789163
-Model first run speed: inference=51.016974ms, post processing=71.36584ms, rendering=6.949688ms, total time=129.332502ms
 Saved object detection result to ../data/catdog-yolov8-seg-out.jpg
-Benchmark time=2.324119083s, count=20, average total time=116.205954ms
+Benchmark time=8.332262773s, count=100, average total time=83.322627ms
 done
 ```
 
@@ -60,15 +60,17 @@ See the help for command line parameters.
 ```
 $ go run yolov8-seg.go --help
 
-Usage of /tmp/go-build401282281/b001/exe/yolov8-seg:
+Usage of /tmp/go-build652765382/b001/exe/yolov8-seg:
   -i string
         Image file to run object detection on (default "../data/catdog.jpg")
   -l string
         Text file containing model labels (default "../data/coco_80_labels_list.txt")
   -m string
-        RKNN compiled YOLO model file (default "../data/yolov8s-seg-640-640-rk3588.rknn")
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov8s-seg-rk3588.rknn")
   -o string
         The output JPG file with object detection markers (default "../data/catdog-yolov8-seg-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
   -r string
         The rendering format used for instance segmentation [outline|mask|dump] (default "outline")
 ```
@@ -90,7 +92,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov8-seg/yolov8-seg.go
+  go run ./example/yolov8-seg/yolov8-seg.go -p rk3588
 ```
 
 
@@ -106,7 +108,7 @@ the object and provides a single transparent overlay to indicate the segment mas
 
 This can be output with the following flag.
 ```
-go run yolov8-seg.go -r mask
+go run yolov8-seg.go -p rk3588 -r mask
 ```
 
 ![catdog-mask.jpg](catdog-mask.jpg)
@@ -114,7 +116,7 @@ go run yolov8-seg.go -r mask
 For visualisation and debugging purposes the segmentation mask can also be dumped
 to an image.
 ```
-go run yolov8-seg.go -r dump
+go run yolov8-seg.go -p rk3588 -r dump
 ```
 
 ![catdog-dump.jpg](catdog-dump.jpg)
@@ -139,6 +141,24 @@ yParams.PrototypeWeight = 320
 // create YOLO Processor instance	
 yoloProcesser := postprocess.NewYOLOv8Seg(yParams)
 ```
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 8.33s          | 83.32ms                          |
+| rk3576   | 10.23s         | 102.33ms                         |
+| rk3566   | 36.02s         | 360.23ms                         |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
+
+
 
 
 ## Background

--- a/example/yolov8-seg/README.md
+++ b/example/yolov8-seg/README.md
@@ -11,7 +11,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOv8-seg example.

--- a/example/yolov8-seg/yolov8-seg.go
+++ b/example/yolov8-seg/yolov8-seg.go
@@ -10,6 +10,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -18,22 +19,29 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov8s-seg-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov8s-seg-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/catdog.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/coco_80_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/catdog-yolov8-seg-out.jpg", "The output JPG file with object detection markers")
 	renderFormat := flag.String("r", "outline", "The rendering format used for instance segmentation [outline|mask|dump]")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)
@@ -172,7 +180,7 @@ func runBenchmark(rt *rknnlite.Runtime, yoloProcesser *postprocess.YOLOv8Seg,
 	mats []gocv.Mat, classNames []string, resizer *preprocess.Resizer,
 	renderFormat string, srcImg gocv.Mat) {
 
-	count := 20
+	count := 100
 	start := time.Now()
 
 	for i := 0; i < count; i++ {

--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -8,7 +8,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOv8 example.

--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -11,15 +11,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOv8 example.
+Run the YOLOv8 example on rk3588 or replace with your Platform model.
 ```
 cd example/yolov8
-go run yolov8.go
+go run yolov8.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 9
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003922
@@ -34,13 +34,13 @@ Output tensors:
   index=7, name=onnx::ReduceSum_365, n_dims=4, dims=[1, 80, 20, 20], n_elems=32000, size=32000, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003817
   index=8, name=369, n_dims=4, dims=[1, 1, 20, 20], n_elems=400, size=400, fmt=NCHW, type=INT8, qnt_type=AFFINE, zp=-128, scale=0.003835
 person @ (109 237 225 535) 0.896928
-bus @ (93 136 548 439) 0.881662
-person @ (475 232 559 521) 0.881662
+bus @ (92 136 548 439) 0.885478
+person @ (475 233 559 521) 0.881662
 person @ (211 241 285 510) 0.832044
 person @ (80 326 123 517) 0.596252
-Model first run speed: inference=49.146842ms, post processing=4.291201ms, rendering=1.419804ms, total time=54.857847ms
+Model first run speed: inference=41.492251ms, post processing=1.968418ms, rendering=714.861µs, total time=44.17553ms
 Saved object detection result to ../data/bus-yolov8-out.jpg
-Benchmark time=805.490284ms, count=20, average total time=40.274514ms
+Benchmark time=3.926217098s, count=100, average total time=39.26217ms
 done
 ```
 
@@ -51,11 +51,30 @@ The saved JPG image with object detection markers.
 
 To use your own RKNN compiled model and images.
 ```
-go run yolov8.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file>
+go run yolov8.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file> -p <platform>
 ```
 
 The labels file should be a text file containing the labels the Model was trained on.
 It should have one label per line.
+
+
+See the help for command line parameters.
+```
+$ go run yolov8.go --help
+
+Usage of /tmp/go-build156306685/b001/exe/yolov8:
+  -i string
+        Image file to run object detection on (default "../data/bus.jpg")
+  -l string
+        Text file containing model labels (default "../data/coco_80_labels_list.txt")
+  -m string
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yolov8s-rk3588.rknn")
+  -o string
+        The output JPG file with object detection markers (default "../data/bus-yolov8-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
+```
+
 
 
 ### Docker
@@ -73,7 +92,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolov8/yolov8.go
+  go run ./example/yolov8/yolov8.go -p rk3588
 ```
 
 
@@ -88,6 +107,24 @@ with your own `YOLOv8Params`.
 
 In the file `postprocess/yolov8.go` see function `YOLOv8COCOParams` for how to
 configure your own custom parameters.
+
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 3.92s          | 39.26ms                          |
+| rk3576   | 3.94s          | 39.48ms                     |
+| rk3566   | 8.86s          | 88.66ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
+
 
 
 ## Background

--- a/example/yolov8/yolov8.go
+++ b/example/yolov8/yolov8.go
@@ -13,6 +13,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -21,21 +22,28 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yolov8s-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yolov8s-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/bus.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/coco_80_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/bus-yolov8-out.jpg", "The output JPG file with object detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)
@@ -147,7 +155,7 @@ func runBenchmark(rt *rknnlite.Runtime, yoloProcesser *postprocess.YOLOv8,
 	mats []gocv.Mat, classNames []string, resizer *preprocess.Resizer,
 	srcImg gocv.Mat) {
 
-	count := 20
+	count := 100
 	start := time.Now()
 
 	for i := 0; i < count; i++ {

--- a/example/yolox/README.md
+++ b/example/yolox/README.md
@@ -8,7 +8,7 @@ You only need to do this once for all examples.
 
 ```
 cd example/
-git clone https://github.com/swdee/go-rknnlite-data.git data
+git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
 Run the YOLOX example.

--- a/example/yolox/README.md
+++ b/example/yolox/README.md
@@ -11,15 +11,15 @@ cd example/
 git clone --depth=1 https://github.com/swdee/go-rknnlite-data.git data
 ```
 
-Run the YOLOX example.
+Run the YOLOX example on rk3588 or replace with your Platform model.
 ```
 cd example/yolox
-go run yolox.go
+go run yolox.go -p rk3588
 ```
 
 This will result in the output of:
 ```
-Driver Version: 0.8.2, API Version: 1.6.0 (9a7b5d24c@2023-12-13T17:31:11)
+Driver Version: 0.9.6, API Version: 2.3.0 (c949ad889d@2024-11-07T11:35:33)
 Model Input Number: 1, Ouput Number: 3
 Input tensors:
   index=0, name=images, n_dims=4, dims=[1, 640, 640, 3], n_elems=1228800, size=1228800, fmt=NHWC, type=INT8, qnt_type=AFFINE, zp=-128, scale=1.000000
@@ -32,9 +32,9 @@ person @ (103 237 223 535) 0.895541
 person @ (210 235 286 513) 0.871337
 person @ (474 235 559 519) 0.830675
 person @ (80 328 118 516) 0.499204
-Model first run speed: inference=44.656729ms, post processing=186.954µs, rendering=1.388305ms, total time=46.231988ms
+Model first run speed: inference=39.329023ms, post processing=88.081µs, rendering=689.195µs, total time=40.106299ms
 Saved object detection result to ../data/bus-yolox-out.jpg
-Benchmark time=3.604234203s, count=100, average total time=36.042342ms
+Benchmark time=3.370110888s, count=100, average total time=33.701108ms
 done
 ```
 
@@ -45,12 +45,29 @@ The saved JPG image with object detection markers.
 
 To use your own RKNN compiled model and images.
 ```
-go run yolox.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file>
+go run yolox.go -m <RKNN model file> -i <image file> -l <labels txt file> -o <output jpg file> -p <platform>
 ```
 
 The labels file should be a text file containing the labels the Model was trained on.
 It should have one label per line.
 
+
+See the help for command line parameters.
+```
+$ go run yolox.go --help
+
+Usage of /tmp/go-build2416613122/b001/exe/yolox:
+  -i string
+        Image file to run object detection on (default "../data/bus.jpg")
+  -l string
+        Text file containing model labels (default "../data/coco_80_labels_list.txt")
+  -m string
+        RKNN compiled YOLO model file (default "../data/models/rk3588/yoloxs-rk3588.rknn")
+  -o string
+        The output JPG file with object detection markers (default "../data/bus-yolox-out.jpg")
+  -p string
+        Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588] (default "rk3588")
+```
 
 ### Docker
 
@@ -67,7 +84,7 @@ docker run --rm \
   -v "/usr/lib/librknnrt.so:/usr/lib/librknnrt.so" \
   -w /go/src/app \
   swdee/go-rknnlite:latest \
-  go run ./example/yolox/yolox.go
+  go run ./example/yolox/yolox.go -p rk3588
 ```
 
 
@@ -82,6 +99,24 @@ with your own `YOLOXParams`.
 
 In the file `postprocess/yolox.go` see function `YOLOXCOCOParams` for how to
 configure your own custom parameters.
+
+
+## Benchmarks
+
+The following table shows a comparison of the benchmark results across the three distinct platforms.
+
+
+| Platform | Execution Time | Average Inference Time Per Image |
+|----------|----------------|----------------------------------|
+| rk3588   | 3.37s          | 33.70ms                          |
+| rk3576   | 3.29s          | 32.98ms                          |
+| rk3566   | 7.61s          | 76.11ms                          |
+
+Note that these examples are only using a single NPU core to run inference on.  The results
+would be different when running a Pool of models using all NPU cores available.  Secondly
+the Rock 4D (rk3576) has DDR5 memory versus the Rock 5B (rk3588) with slower DDR4 memory.
+
+
 
 
 ## Background

--- a/example/yolox/yolox.go
+++ b/example/yolox/yolox.go
@@ -10,6 +10,7 @@ import (
 	"gocv.io/x/gocv"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -18,21 +19,28 @@ func main() {
 	log.SetFlags(0)
 
 	// read in cli flags
-	modelFile := flag.String("m", "../data/yoloxs-640-640-rk3588.rknn", "RKNN compiled YOLO model file")
+	modelFile := flag.String("m", "../data/models/rk3588/yoloxs-rk3588.rknn", "RKNN compiled YOLO model file")
 	imgFile := flag.String("i", "../data/bus.jpg", "Image file to run object detection on")
 	labelFile := flag.String("l", "../data/coco_80_labels_list.txt", "Text file containing model labels")
 	saveFile := flag.String("o", "../data/bus-yolox-out.jpg", "The output JPG file with object detection markers")
+	rkPlatform := flag.String("p", "rk3588", "Rockchip CPU Model number [rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588]")
 
 	flag.Parse()
 
-	err := rknnlite.SetCPUAffinity(rknnlite.RK3588FastCores)
+	err := rknnlite.SetCPUAffinityByPlatform(*rkPlatform, rknnlite.FastCores)
 
 	if err != nil {
 		log.Printf("Failed to set CPU Affinity: %v\n", err)
 	}
 
+	// check if user specified model file or if default is being used.  if default
+	// then pick the default platform model to use.
+	if f := flag.Lookup("m"); f != nil && f.Value.String() == f.DefValue && *rkPlatform != "rk3588" {
+		*modelFile = strings.ReplaceAll(*modelFile, "rk3588", *rkPlatform)
+	}
+
 	// create rknn runtime instance
-	rt, err := rknnlite.NewRuntime(*modelFile, rknnlite.NPUCoreAuto)
+	rt, err := rknnlite.NewRuntimeByPlatform(*rkPlatform, *modelFile)
 
 	if err != nil {
 		log.Fatal("Error initializing RKNN runtime: ", err)

--- a/pool.go
+++ b/pool.go
@@ -1,6 +1,8 @@
 package rknnlite
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -39,6 +41,34 @@ func NewPool(size int, modelFile string, cores []CoreMask) (*Pool, error) {
 	}
 
 	return p, nil
+}
+
+// NewPoolByPlatform creates a new runtime pool that pins the runtimes to the
+// NPU cores for the given rockchip platform string of
+// rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588
+func NewPoolByPlatform(platform string, size int, modelFile string) (*Pool, error) {
+
+	platform = strings.TrimSpace(platform)
+	platform = strings.ToLower(platform)
+
+	// default to NPUSkipSetCore
+	var useCores []CoreMask
+
+	switch platform {
+	case "rk3562", "rk3566", "rk3568":
+		useCores = RK3562
+
+	case "rk3576":
+		useCores = RK3576
+
+	case "rk3582", "rk3588":
+		useCores = RK3588
+
+	default:
+		return nil, fmt.Errorf("unknown platform: %s", platform)
+	}
+
+	return NewPool(size, modelFile, useCores)
 }
 
 // Gets a runtime from the pool

--- a/toolkit/Dockerfile
+++ b/toolkit/Dockerfile
@@ -49,6 +49,10 @@ RUN mkdir -p /opt/models/mobilenet_v1 && \
     wget -O /opt/models/mobilenet_v1/model_config.yml \
       https://raw.githubusercontent.com/airockchip/rknn-toolkit2/refs/heads/master/rknn-toolkit2/examples/tflite/mobilenet_v1_qat/model_config.yml
 
+# download other source models
+RUN wget -O /opt/models/license_plate_detector.onnx \
+      https://github.com/swdee/go-rknnlite-data/raw/refs/heads/master/models/onnx/license_plate_detector.onnx
+
 # Clone the RKNN Model Zoo into /opt/rknn_model_zoo
 RUN git clone --depth 1 https://github.com/airockchip/rknn_model_zoo.git /opt/rknn_model_zoo
 

--- a/toolkit/Dockerfile
+++ b/toolkit/Dockerfile
@@ -42,6 +42,12 @@ RUN mkdir -p /opt/models && \
     wget -O /opt/models/ppocrv4_rec.onnx \
       https://ftrg.zbox.filez.com/v2/delivery/data/95f00b0fc900458ba134f8b180b3f7a1/examples/PPOCR/ppocrv4_rec.onnx
 
+# download the tflite model data
+RUN mkdir -p /opt/models/mobilenet_v1 && \
+    wget -O /opt/models/mobilenet_v1/mobilenet_v1_1.0_224_quant.tflite \
+      https://github.com/airockchip/rknn-toolkit2/raw/refs/heads/master/rknn-toolkit2/examples/tflite/mobilenet_v1_qat/mobilenet_v1_1.0_224_quant.tflite && \
+    wget -O /opt/models/mobilenet_v1/model_config.yml \
+      https://raw.githubusercontent.com/airockchip/rknn-toolkit2/refs/heads/master/rknn-toolkit2/examples/tflite/mobilenet_v1_qat/model_config.yml
 
 # Clone the RKNN Model Zoo into /opt/rknn_model_zoo
 RUN git clone --depth 1 https://github.com/airockchip/rknn_model_zoo.git /opt/rknn_model_zoo
@@ -62,7 +68,6 @@ RUN ln -s /opt/models/mobilenetv2-12.onnx  /opt/rknn_model_zoo/examples/mobilene
     ln -s /opt/models/ppocrv4_det.onnx  /opt/rknn_model_zoo/examples/PPOCR/PPOCR-Det/model/ && \
     ln -s /opt/models/ppocrv4_rec.onnx  /opt/rknn_model_zoo/examples/PPOCR/PPOCR-Rec/model/
 
-
 # Upgrade pip to the latest version
 RUN pip install --upgrade pip
 
@@ -73,6 +78,11 @@ RUN pip install -r \
 # Install the RKNN-Toolkit2 wheel
 RUN pip install \
     "https://github.com/airockchip/rknn-toolkit2/raw/refs/tags/v2.3.2/rknn-toolkit2/packages/x86_64/rknn_toolkit2-2.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+
+# install extra python deps for converting tflite models
+RUN pip install --no-cache-dir \
+    pyyaml \
+    "tensorflow<=2.16.0rc0"
 
 # By default do nothing
 CMD ["bash"]

--- a/toolkit/Dockerfile
+++ b/toolkit/Dockerfile
@@ -49,10 +49,6 @@ RUN mkdir -p /opt/models/mobilenet_v1 && \
     wget -O /opt/models/mobilenet_v1/model_config.yml \
       https://raw.githubusercontent.com/airockchip/rknn-toolkit2/refs/heads/master/rknn-toolkit2/examples/tflite/mobilenet_v1_qat/model_config.yml
 
-# download other source models
-RUN wget -O /opt/models/license_plate_detector.onnx \
-      https://github.com/swdee/go-rknnlite-data/raw/refs/heads/master/models/onnx/license_plate_detector.onnx
-
 # Clone the RKNN Model Zoo into /opt/rknn_model_zoo
 RUN git clone --depth 1 https://github.com/airockchip/rknn_model_zoo.git /opt/rknn_model_zoo
 
@@ -71,6 +67,11 @@ RUN ln -s /opt/models/mobilenetv2-12.onnx  /opt/rknn_model_zoo/examples/mobilene
     ln -s /opt/models/lprnet.onnx  /opt/rknn_model_zoo/examples/LPRNet/model/ && \
     ln -s /opt/models/ppocrv4_det.onnx  /opt/rknn_model_zoo/examples/PPOCR/PPOCR-Det/model/ && \
     ln -s /opt/models/ppocrv4_rec.onnx  /opt/rknn_model_zoo/examples/PPOCR/PPOCR-Rec/model/
+
+# download LPD model and create convert script for it in the model zoo
+RUN git clone --depth 1 https://github.com/swdee/lpd-yolov8.git /opt/lpd-yolov8 && \
+    cp /opt/rknn_model_zoo/examples/yolov8/python/convert.py /opt/rknn_model_zoo/examples/yolov8/python/convert-lpd.py && \
+    sed -i "s|^DATASET_PATH *= *['\"].*['\"]|DATASET_PATH = '/opt/lpd-yolov8/subset.txt'|" /opt/rknn_model_zoo/examples/yolov8/python/convert-lpd.py
 
 # Upgrade pip to the latest version
 RUN pip install --upgrade pip

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -14,12 +14,13 @@ Along with the [compile-models.sh](compile-models.sh) script the original ONNX m
 in the [examples](../example/) can be easily
 compiled to RKNN format for your target platform: rk3562, rk3566, rk3568, rk3576, or rk3588. 
 
+Note that rk3566 and rk3568 share the same RKNN compiled model, as does rk3582 and rk3588 are the same.
 
 
 ## Compile Example Models
 
 Models compiled to RKNN format used in the [examples](../example/) are already 
-available at [example/data/models/](../example/data/models/), however these are generated 
+available at [example/data/models/](https://github.com/swdee/go-rknnlite-data/tree/master/models), however these are generated 
 as follows on a x86 workstation.
 
 ```

--- a/toolkit/compile-models.sh
+++ b/toolkit/compile-models.sh
@@ -28,6 +28,7 @@ MODELS=(
   "PPOCR/PPOCR-Det   convert.py        ../model/ppocrv4_det.onnx          i8    ''          ppocrv4_det"
   "PPOCR/PPOCR-Rec   convert.py        ../model/ppocrv4_rec.onnx          fp    ''          ppocrv4_rec"
   "mobilenet_v1      rknn_convert      /opt/models/mobilenet_v1/model_config.yml    ''    ''    mobilenet_v1"
+  "yolov8            convert.py        /opt/models/license_plate_detector.onnx      i8    ''    lpd-yolov8n"
 )
 
 # compile all entries (or just filter) for one platform

--- a/toolkit/compile-models.sh
+++ b/toolkit/compile-models.sh
@@ -28,7 +28,7 @@ MODELS=(
   "PPOCR/PPOCR-Det   convert.py        ../model/ppocrv4_det.onnx          i8    ''          ppocrv4_det"
   "PPOCR/PPOCR-Rec   convert.py        ../model/ppocrv4_rec.onnx          fp    ''          ppocrv4_rec"
   "mobilenet_v1      rknn_convert      /opt/models/mobilenet_v1/model_config.yml    ''    ''    mobilenet_v1"
-  "yolov8            convert.py        /opt/models/license_plate_detector.onnx      i8    ''    lpd-yolov8n"
+  "yolov8            convert-lpd.py    /opt/lpd-yolov8/lpd-yolov8n.onnx             i8    ''    lpd-yolov8n"
 )
 
 # compile all entries (or just filter) for one platform


### PR DESCRIPTION
* Added support for all Rk35xx series SoC's, which includes changes to all examples and supply of RKNN compiled models for each.
* Adjust Docker image to include Go dependencies, so these don't need to be downloaded every time.
* Added benchmarks for rk3588, rk3576, and rk3566 for comparison