### PR TITLE
feat: add NewRuntimeFromBytes and refactor runtime initialization

### DIFF
--- a/inference_integration_test.go
+++ b/inference_integration_test.go
@@ -4,10 +4,11 @@
 package rknnlite
 
 import (
-	"gocv.io/x/gocv"
 	"image"
 	"os"
 	"testing"
+
+	"gocv.io/x/gocv"
 )
 
 func TestMobileNetTop5(t *testing.T) {
@@ -26,6 +27,112 @@ func TestMobileNetTop5(t *testing.T) {
 
 	// Initialize runtime
 	rt, err := NewRuntime(modelFile, NPUCoreAuto)
+
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+
+	defer rt.Close()
+
+	// load image
+	img := gocv.IMRead(imgFile, gocv.IMReadColor)
+
+	if img.Empty() {
+		t.Fatalf("Error reading image from: %s", imgFile)
+	}
+
+	// convert colorspace and resize image
+	rgbImg := gocv.NewMat()
+	gocv.CvtColor(img, &rgbImg, gocv.ColorBGRToRGB)
+
+	cropImg := rgbImg.Clone()
+	scaleSize := image.Pt(int(rt.InputAttrs()[0].Dims[1]), int(rt.InputAttrs()[0].Dims[2]))
+	gocv.Resize(rgbImg, &cropImg, scaleSize, 0, 0, gocv.InterpolationArea)
+
+	defer img.Close()
+	defer rgbImg.Close()
+	defer cropImg.Close()
+
+	// run inference
+	outputs, err := rt.Inference([]gocv.Mat{cropImg})
+
+	if err != nil {
+		t.Fatalf("Inference error: %v", err)
+	}
+
+	defer func() {
+		if err := outputs.Free(); err != nil {
+			t.Errorf("Free Outputs: %v", err)
+		}
+	}()
+
+	// Extract Top5
+	top5 := GetTop5(outputs.Output)
+
+	if len(top5) != 5 {
+		t.Fatalf("expected 5 results, got %d", len(top5))
+	}
+
+	// Probabilities must be in [0,1] and descending
+	for i, p := range top5 {
+
+		if p.Probability < 0 || p.Probability > 1 {
+			t.Errorf("entry %d: probability %v out of [0,1]", i, p.Probability)
+		}
+
+		if i > 0 && p.Probability > top5[i-1].Probability {
+			t.Errorf("probabilities not descending: index %d has %v > previous %v",
+				i, p.Probability, top5[i-1].Probability)
+		}
+	}
+
+	// Label indices must be in range [0, numClasses)
+	numClasses := int(rt.OutputAttrs()[0].Dims[1])
+
+	for i, p := range top5 {
+		if int(p.LabelIndex) < 0 || int(p.LabelIndex) >= numClasses {
+			t.Errorf("entry %d: label index %d out of range [0,%d)", i, p.LabelIndex, numClasses)
+		}
+	}
+
+	// Sanity check: at least one probability above a tiny epsilon
+	const eps = 1e-3
+	var found bool
+
+	for _, p := range top5 {
+		if p.Probability > eps {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("all probabilities ≤ %v, something's wrong", eps)
+	}
+}
+
+func TestMobileNetTop5FromBytes(t *testing.T) {
+
+	modelFile := os.Getenv("RKNN_MODEL")
+
+	if modelFile == "" {
+		t.Fatalf("No Model file provided in RKNN_MODEL")
+	}
+
+	imgFile := os.Getenv("RKNN_IMAGE")
+
+	if imgFile == "" {
+		t.Fatalf("No Image file provided in RKNN_IMAGE")
+	}
+
+	// Read model file into memory to test NewRuntimeFromBytes initialization
+	modelBytes, err := os.ReadFile(modelFile)
+	if err != nil {
+		t.Fatalf("model read error: %v", err)
+	}
+
+	// Initialize runtime from byte slice
+	rt, err := NewRuntimeFromBytes(modelBytes, NPUCoreAuto)
 
 	if err != nil {
 		t.Fatalf("NewRuntime failed: %v", err)

--- a/inference_integration_test.go
+++ b/inference_integration_test.go
@@ -4,14 +4,31 @@
 package rknnlite
 
 import (
+	"gocv.io/x/gocv"
 	"image"
 	"os"
 	"testing"
-
-	"gocv.io/x/gocv"
 )
 
 func TestMobileNetTop5(t *testing.T) {
+	testMobileNetTop5Common(t, func(modelFile string) (*Runtime, error) {
+		return NewRuntime(modelFile, NPUCoreAuto)
+	})
+}
+
+func TestMobileNetTop5FromBytes(t *testing.T) {
+	testMobileNetTop5Common(t, func(modelFile string) (*Runtime, error) {
+		modelBytes, err := os.ReadFile(modelFile)
+		if err != nil {
+			return nil, err
+		}
+
+		return NewRuntimeFromBytes(modelBytes, NPUCoreAuto)
+	})
+}
+
+func testMobileNetTop5Common(t *testing.T, newRuntime func(modelFile string) (*Runtime, error)) {
+	t.Helper()
 
 	modelFile := os.Getenv("RKNN_MODEL")
 
@@ -26,10 +43,10 @@ func TestMobileNetTop5(t *testing.T) {
 	}
 
 	// Initialize runtime
-	rt, err := NewRuntime(modelFile, NPUCoreAuto)
+	rt, err := newRuntime(modelFile)
 
 	if err != nil {
-		t.Fatalf("NewRuntime failed: %v", err)
+		t.Fatalf("runtime init failed: %v", err)
 	}
 
 	defer rt.Close()
@@ -81,8 +98,10 @@ func TestMobileNetTop5(t *testing.T) {
 		}
 
 		if i > 0 && p.Probability > top5[i-1].Probability {
-			t.Errorf("probabilities not descending: index %d has %v > previous %v",
-				i, p.Probability, top5[i-1].Probability)
+			t.Errorf(
+				"probabilities not descending: index %d has %v > previous %v",
+				i, p.Probability, top5[i-1].Probability,
+			)
 		}
 	}
 
@@ -91,119 +110,16 @@ func TestMobileNetTop5(t *testing.T) {
 
 	for i, p := range top5 {
 		if int(p.LabelIndex) < 0 || int(p.LabelIndex) >= numClasses {
-			t.Errorf("entry %d: label index %d out of range [0,%d)", i, p.LabelIndex, numClasses)
+			t.Errorf(
+				"entry %d: label index %d out of range [0,%d)",
+				i, p.LabelIndex, numClasses,
+			)
 		}
 	}
 
 	// Sanity check: at least one probability above a tiny epsilon
 	const eps = 1e-3
-	var found bool
-
-	for _, p := range top5 {
-		if p.Probability > eps {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		t.Errorf("all probabilities ≤ %v, something's wrong", eps)
-	}
-}
-
-func TestMobileNetTop5FromBytes(t *testing.T) {
-
-	modelFile := os.Getenv("RKNN_MODEL")
-
-	if modelFile == "" {
-		t.Fatalf("No Model file provided in RKNN_MODEL")
-	}
-
-	imgFile := os.Getenv("RKNN_IMAGE")
-
-	if imgFile == "" {
-		t.Fatalf("No Image file provided in RKNN_IMAGE")
-	}
-
-	// Read model file into memory to test NewRuntimeFromBytes initialization
-	modelBytes, err := os.ReadFile(modelFile)
-	if err != nil {
-		t.Fatalf("model read error: %v", err)
-	}
-
-	// Initialize runtime from byte slice
-	rt, err := NewRuntimeFromBytes(modelBytes, NPUCoreAuto)
-
-	if err != nil {
-		t.Fatalf("NewRuntime failed: %v", err)
-	}
-
-	defer rt.Close()
-
-	// load image
-	img := gocv.IMRead(imgFile, gocv.IMReadColor)
-
-	if img.Empty() {
-		t.Fatalf("Error reading image from: %s", imgFile)
-	}
-
-	// convert colorspace and resize image
-	rgbImg := gocv.NewMat()
-	gocv.CvtColor(img, &rgbImg, gocv.ColorBGRToRGB)
-
-	cropImg := rgbImg.Clone()
-	scaleSize := image.Pt(int(rt.InputAttrs()[0].Dims[1]), int(rt.InputAttrs()[0].Dims[2]))
-	gocv.Resize(rgbImg, &cropImg, scaleSize, 0, 0, gocv.InterpolationArea)
-
-	defer img.Close()
-	defer rgbImg.Close()
-	defer cropImg.Close()
-
-	// run inference
-	outputs, err := rt.Inference([]gocv.Mat{cropImg})
-
-	if err != nil {
-		t.Fatalf("Inference error: %v", err)
-	}
-
-	defer func() {
-		if err := outputs.Free(); err != nil {
-			t.Errorf("Free Outputs: %v", err)
-		}
-	}()
-
-	// Extract Top5
-	top5 := GetTop5(outputs.Output)
-
-	if len(top5) != 5 {
-		t.Fatalf("expected 5 results, got %d", len(top5))
-	}
-
-	// Probabilities must be in [0,1] and descending
-	for i, p := range top5 {
-
-		if p.Probability < 0 || p.Probability > 1 {
-			t.Errorf("entry %d: probability %v out of [0,1]", i, p.Probability)
-		}
-
-		if i > 0 && p.Probability > top5[i-1].Probability {
-			t.Errorf("probabilities not descending: index %d has %v > previous %v",
-				i, p.Probability, top5[i-1].Probability)
-		}
-	}
-
-	// Label indices must be in range [0, numClasses)
-	numClasses := int(rt.OutputAttrs()[0].Dims[1])
-
-	for i, p := range top5 {
-		if int(p.LabelIndex) < 0 || int(p.LabelIndex) >= numClasses {
-			t.Errorf("entry %d: label index %d out of range [0,%d)", i, p.LabelIndex, numClasses)
-		}
-	}
-
-	// Sanity check: at least one probability above a tiny epsilon
-	const eps = 1e-3
-	var found bool
+	found := false
 
 	for _, p := range top5 {
 		if p.Probability > eps {

--- a/runtime.go
+++ b/runtime.go
@@ -123,49 +123,69 @@ type Runtime struct {
 // NewRuntime returns a RKNN run time instance.  Provide the full path and
 // filename of the RKNN compiled model file to run.
 func NewRuntime(modelFile string, core CoreMask) (*Runtime, error) {
-
 	r := &Runtime{
 		wantFloat: true,
 	}
 
-	err := r.init(modelFile)
-
-	if err != nil {
+	if err := r.init(modelFile); err != nil {
 		return nil, err
 	}
+
+	if err := r.setup(core); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// NewRuntimeFromBytes returns a RKNN run time instance. Provide the model as a byte buffer.
+func NewRuntimeFromBytes(modelBuffer []byte, core CoreMask) (*Runtime, error) {
+	r := &Runtime{
+		wantFloat: true,
+	}
+
+	if err := r.initFromBytes(modelBuffer); err != nil {
+		return nil, err
+	}
+
+	if err := r.setup(core); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// setup performs the common initialization steps for the RKNN runtime
+func (r *Runtime) setup(core CoreMask) error {
+	var err error
 
 	// setCoreMask is only supported on RK3588, allow skipping for other Rockchip models
 	// like RK3566
 	if core != NPUSkipSetCore {
-		err = r.setCoreMask(core)
-
-		if err != nil {
-			return nil, err
+		if err = r.setCoreMask(core); err != nil {
+			return err
 		}
 	}
 
 	// cache IONumber
 	r.ioNum, err = r.QueryModelIONumber()
-
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// query Input tensors
 	r.inputAttrs, err = r.QueryInputTensors()
-
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// query Output tensors
 	r.outputAttrs, err = r.QueryOutputTensors()
-
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return r, nil
+	return nil
 }
 
 // init wraps C.rknn_init which initializes the RKNN context with the given
@@ -191,6 +211,24 @@ func (r *Runtime) init(modelFile string) error {
 
 	// call the C function.
 	ret := C.rknn_init(&r.ctx, unsafe.Pointer(cModelFile), 0, 0, nil)
+
+	if ret != C.RKNN_SUCC {
+		return fmt.Errorf("C.rknn_init call failed with code %d, error: %s",
+			ret, ErrorCodes(ret).String())
+	}
+
+	return nil
+}
+
+func (r *Runtime) initFromBytes(modelBytes []byte) error {
+
+	if len(modelBytes) == 0 {
+		return fmt.Errorf("bytes is empty")
+	}
+
+	ptr := unsafe.Pointer(&modelBytes[0])
+	size := C.uint32_t(len(modelBytes))
+	ret := C.rknn_init(&r.ctx, ptr, size, 0, nil)
 
 	if ret != C.RKNN_SUCC {
 		return fmt.Errorf("C.rknn_init call failed with code %d, error: %s",
@@ -294,22 +332,35 @@ func (r *Runtime) OutputAttrs() []TensorAttr {
 // rk3562|rk3566|rk3568|rk3576|rk3582|rk3582|rk3588
 // Provide the full path and filename of the RKNN compiled model file to run
 func NewRuntimeByPlatform(platform string, modelFile string) (*Runtime, error) {
+	useCore, err := getCoreMaskByPlatform(platform)
+	if err != nil {
+		return nil, err
+	}
+	return NewRuntime(modelFile, useCore)
+}
 
+// NewRuntimeByPlatformFromBytes returns a RKNN run time instance and automatically
+// selects the NPU cores to run on the given platform string.
+func NewRuntimeByPlatformFromBytes(platform string, modelBytes []byte) (*Runtime, error) {
+	useCore, err := getCoreMaskByPlatform(platform)
+	if err != nil {
+		return nil, err
+	}
+	return NewRuntimeFromBytes(modelBytes, useCore)
+}
+
+func getCoreMaskByPlatform(platform string) (CoreMask, error) {
 	platform = strings.TrimSpace(platform)
 	platform = strings.ToLower(platform)
 
-	var useCore CoreMask
-
 	switch platform {
 	case "rk3562", "rk3566", "rk3568":
-		useCore = NPUSkipSetCore
+		return NPUSkipSetCore, nil
 
 	case "rk3576", "rk3582", "rk3588":
-		useCore = NPUCoreAuto
+		return NPUCoreAuto, nil
 
 	default:
-		return nil, fmt.Errorf("unknown platform: %s", platform)
+		return 0, fmt.Errorf("unknown platform: %s", platform)
 	}
-
-	return NewRuntime(modelFile, useCore)
 }

--- a/runtime.go
+++ b/runtime.go
@@ -118,20 +118,29 @@ type Runtime struct {
 	// inputTypeFloat32 indicates if we pass the input gocv.Mat's data as float32
 	// to the RKNN backend
 	inputTypeFloat32 bool
+	// C-owned model buffer when initialized FromBytes()
+	// Keep this alive for the lifetime of the RKNN context
+	modelData unsafe.Pointer
+	modelSize C.uint32_t
 }
 
 // NewRuntime returns a RKNN run time instance.  Provide the full path and
 // filename of the RKNN compiled model file to run.
 func NewRuntime(modelFile string, core CoreMask) (*Runtime, error) {
+
 	r := &Runtime{
 		wantFloat: true,
 	}
 
-	if err := r.init(modelFile); err != nil {
+	err := r.init(modelFile)
+
+	if err != nil {
 		return nil, err
 	}
 
-	if err := r.setup(core); err != nil {
+	err = r.setup(core)
+
+	if err != nil {
 		return nil, err
 	}
 
@@ -140,15 +149,20 @@ func NewRuntime(modelFile string, core CoreMask) (*Runtime, error) {
 
 // NewRuntimeFromBytes returns a RKNN run time instance. Provide the model as a byte buffer.
 func NewRuntimeFromBytes(modelBuffer []byte, core CoreMask) (*Runtime, error) {
+
 	r := &Runtime{
 		wantFloat: true,
 	}
 
-	if err := r.initFromBytes(modelBuffer); err != nil {
+	err := r.initFromBytes(modelBuffer)
+
+	if err != nil {
 		return nil, err
 	}
 
-	if err := r.setup(core); err != nil {
+	err = r.setup(core)
+
+	if err != nil {
 		return nil, err
 	}
 
@@ -220,20 +234,32 @@ func (r *Runtime) init(modelFile string) error {
 	return nil
 }
 
+// initFromBytes copies modelBytes into C-allocated memory and initializes
+// the RKNN context from that C-owned model buffer so its lifetime is managed
+// independently of the Go GC.
 func (r *Runtime) initFromBytes(modelBytes []byte) error {
 
 	if len(modelBytes) == 0 {
-		return fmt.Errorf("bytes is empty")
+		return fmt.Errorf("model bytes is empty")
 	}
 
-	ptr := unsafe.Pointer(&modelBytes[0])
+	// Allocate C-owned memory so the model buffer lifetime is under our control.
+	modelData := C.CBytes(modelBytes)
+	if modelData == nil {
+		return fmt.Errorf("failed to allocate C memory for model bytes")
+	}
+
 	size := C.uint32_t(len(modelBytes))
-	ret := C.rknn_init(&r.ctx, ptr, size, 0, nil)
+	ret := C.rknn_init(&r.ctx, modelData, size, 0, nil)
 
 	if ret != C.RKNN_SUCC {
+		C.free(modelData)
 		return fmt.Errorf("C.rknn_init call failed with code %d, error: %s",
 			ret, ErrorCodes(ret).String())
 	}
+
+	r.modelData = modelData
+	r.modelSize = size
 
 	return nil
 }
@@ -263,7 +289,19 @@ func (r *Runtime) Close() error {
 			ret, ErrorCodes(ret).String())
 	}
 
+	// free any memory with loaded model data
+	r.freeModelData()
+
 	return nil
+}
+
+// freeModelData frees C memory used to store Model when loaded from bytes
+func (r *Runtime) freeModelData() {
+	if r.modelData != nil {
+		C.free(r.modelData)
+		r.modelData = nil
+		r.modelSize = 0
+	}
 }
 
 // SetWantFloat defines if the Model load requires Output tensors to be converted
@@ -350,17 +388,21 @@ func NewRuntimeByPlatformFromBytes(platform string, modelBytes []byte) (*Runtime
 }
 
 func getCoreMaskByPlatform(platform string) (CoreMask, error) {
+
 	platform = strings.TrimSpace(platform)
 	platform = strings.ToLower(platform)
 
 	switch platform {
 	case "rk3562", "rk3566", "rk3568":
+
 		return NPUSkipSetCore, nil
 
 	case "rk3576", "rk3582", "rk3588":
+
 		return NPUCoreAuto, nil
 
 	default:
+
 		return 0, fmt.Errorf("unknown platform: %s", platform)
 	}
 }


### PR DESCRIPTION
  Summary
  This PR adds support for initializing the RKNN runtime directly from a byte slice, offering more flexibility for applications that load models from memory,
  embedded assets, or network streams. It also refactors the internal initialization logic to reduce code duplication.

  Changes
   * New Feature: Added NewRuntimeFromBytes(modelBuffer []byte, core CoreMask) to allow model loading without a direct file path.
   * Refactoring: Introduced a private setup method in runtime.go to consolidate common initialization steps (setting core mask, querying IO numbers, and
     input/output tensors).
   * Testing: Added a new integration test TestMobileNetTop5FromBytes in inference_integration_test.go to verify the new initialization path.

  Verification
   * Verified that NewRuntime still functions correctly after refactoring.
   * Confirmed that NewRuntimeFromBytes successfully initializes the runtime and produces correct inference results in the new integration test.